### PR TITLE
Include traveler preferences in summary pipeline

### DIFF
--- a/agents/summary_agent.py
+++ b/agents/summary_agent.py
@@ -6,7 +6,8 @@ llm = ChatOpenAI(
     openai_api_key=os.getenv("OPENAI_API_KEY")
 )
 
-def summary_task(calendar, photo_spots):
+
+def summary_task(calendar, photo_spots, preferences):
     prompt = f"""
 You are a **Trip Summarizer** for a high-end AI travel companion.
 
@@ -22,16 +23,21 @@ You are a **Trip Summarizer** for a high-end AI travel companion.
 
 ---
 
+**Traveler Vibe & Preferences**:
+{preferences}
+
+---
+
 Summarize the trip, day by day, as if writing for a luxury travel magazine. Highlight the why, scenic flow, and meaningful moments using the following structure:
 
-- **Breakfast:** Suggest a breakfast spot or meal aligned with preferences.
-- **Morning Activity:** Recommend a cultural, relaxing, or inspiring activity nearby that aligns with preferences.
-- **Snack (Optional):** Suggest a small local snack or café stop.
-- **Lunch:** Recommend a restaurant or food experience that aligns with preferences.
-- **Afternoon Activity:** Choose something scenic, creative, or thoughtful that aligns with preferences.
-- **Snack (Optional):** Include only if the day’s pace benefits from it.
-- **Dinner:** Curated dinner spot or culinary experience that that aligns with preferences.
-- **After-Dinner Activity (Optional):** Suggestions for evenings that aligns with preferences.
+- **Breakfast:** Suggest a breakfast spot or meal that fits the traveler vibe ({preferences}).
+- **Morning Activity:** Recommend a cultural, relaxing, or inspiring activity nearby that reflects the traveler vibe ({preferences}).
+- **Snack (Optional):** Suggest a small local snack or café stop that complements the vibe ({preferences}).
+- **Lunch:** Recommend a restaurant or food experience in tune with the vibe ({preferences}).
+- **Afternoon Activity:** Choose something scenic, creative, or thoughtful that resonates with the vibe ({preferences}).
+- **Snack (Optional):** Include only if the day’s pace benefits from it and it enhances the vibe ({preferences}).
+- **Dinner:** Curated dinner spot or culinary experience that matches the vibe ({preferences}).
+- **After-Dinner Activity (Optional):** Suggest evenings that stay true to the vibe ({preferences}).
 
 
 

--- a/workflows/trip_planner_flow.py
+++ b/workflows/trip_planner_flow.py
@@ -9,5 +9,5 @@ def run_trip_pipeline(destination, dates, preferences):
     filtered_data = taste_task(raw_data, preferences)
     calendar = planner_task(filtered_data, dates, preferences)
     scenic_spots = vision_task(destination)
-    summary = summary_task(calendar, scenic_spots)
+    summary = summary_task(calendar, scenic_spots, preferences)
     return summary


### PR DESCRIPTION
## Summary
- update the summary agent so its task accepts traveler preferences and reflects the stated vibe throughout the prompt
- propagate the preferences argument through the trip pipeline when building the final summary

## Testing
- python - <<'PY'
from unittest.mock import patch

import agents.researcher_agent as researcher_agent
import agents.taste_agent as taste_agent
import agents.planner_agent as planner_agent
import agents.vision_agent as vision_agent
import agents.summary_agent as summary_agent
from workflows.trip_planner_flow import run_trip_pipeline

class DummyLLM:
    def __init__(self, response):
        self.response = response
        self.last_prompt = None
    def predict(self, prompt):
        self.last_prompt = prompt
        return self.response

preferences = "Peaceful, tea, slow vibe"

with patch.object(researcher_agent, "llm", DummyLLM("research-data")), \
     patch.object(taste_agent, "llm", DummyLLM("taste-data")), \
     patch.object(planner_agent, "llm", DummyLLM("itinerary")), \
     patch.object(vision_agent, "llm", DummyLLM("photo-spots")):
    dummy_summary_llm = DummyLLM("summary")
    with patch.object(summary_agent, "llm", dummy_summary_llm):
        run_trip_pipeline("Kyoto", "Nov 5–9", preferences)
        called_prompt = dummy_summary_llm.last_prompt
        assert called_prompt is not None
        assert preferences in called_prompt
        assert "Traveler Vibe & Preferences" in called_prompt
        assert called_prompt.count(preferences) >= 2
        print("Prompt validated.")
PY

------
https://chatgpt.com/codex/tasks/task_e_68cc9c165a6c83289d07518ddd2f8976