### PR TITLE
Add Google Maps API client with caching support

### DIFF
--- a/meguru/core/db.py
+++ b/meguru/core/db.py
@@ -1,0 +1,113 @@
+"""Database helpers for working with the Supabase/Postgres cache."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Any, Dict, Generator, Optional, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import psycopg2  # type: ignore[import-not-found]
+    from psycopg2.extras import Json, RealDictCursor  # type: ignore[import-not-found]
+    from psycopg2.extensions import connection as PGConnection  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - handled gracefully in tests
+    psycopg2 = None  # type: ignore[assignment]
+    Json = None  # type: ignore[assignment]
+    RealDictCursor = None  # type: ignore[assignment]
+    PGConnection = Any  # type: ignore[assignment]
+
+CACHE_TABLE_NAME = "api_cache"
+
+
+def get_connection(dsn: Optional[str] = None) -> PGConnection:
+    """Return a new database connection using the configured DSN."""
+
+    if psycopg2 is None:  # pragma: no cover - dependency missing in lightweight environments
+        raise RuntimeError("psycopg2 is not installed; database operations are unavailable")
+    connection_dsn = dsn or os.getenv("SUPABASE_DB_URL") or os.getenv("DATABASE_URL")
+    if not connection_dsn:
+        raise RuntimeError("No database DSN configured via SUPABASE_DB_URL or DATABASE_URL")
+    return psycopg2.connect(connection_dsn)
+
+
+@contextmanager
+def connection_ctx(dsn: Optional[str] = None) -> Generator[PGConnection, None, None]:
+    """Context manager that yields a database connection and ensures it is closed."""
+
+    connection = get_connection(dsn)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def ensure_cache_table(connection: PGConnection) -> None:
+    """Create the cache table if it does not already exist."""
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {CACHE_TABLE_NAME} (
+                key TEXT PRIMARY KEY,
+                value JSONB NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+    connection.commit()
+
+
+def get_cache_entry(
+    connection: PGConnection, key: str
+) -> Optional[Tuple[Dict[str, Any], datetime]]:
+    """Return a cached value and its timestamp for the supplied key."""
+
+    cursor_kwargs: Dict[str, Any] = {}
+    if RealDictCursor is not None:
+        cursor_kwargs["cursor_factory"] = RealDictCursor
+    with connection.cursor(**cursor_kwargs) as cursor:
+        cursor.execute(
+            f"SELECT value, updated_at FROM {CACHE_TABLE_NAME} WHERE key = %s",
+            (key,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        value = row.get("value")
+        updated_at = row.get("updated_at")
+        if value is None or updated_at is None:
+            return None
+        if isinstance(value, Mapping):
+            return dict(value), updated_at
+        return value, updated_at
+
+
+def set_cache_entry(
+    connection: PGConnection, key: str, value: Dict[str, Any]
+) -> None:
+    """Insert or update a cache entry."""
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            INSERT INTO {CACHE_TABLE_NAME} (key, value, updated_at)
+            VALUES (%s, %s, NOW())
+            ON CONFLICT (key) DO UPDATE
+            SET value = EXCLUDED.value,
+                updated_at = NOW()
+            """,
+            (key, Json(value) if Json is not None else value),
+        )
+    connection.commit()
+
+
+__all__ = [
+    "CACHE_TABLE_NAME",
+    "connection_ctx",
+    "ensure_cache_table",
+    "get_cache_entry",
+    "get_connection",
+    "set_cache_entry",
+]

--- a/meguru/core/google_api.py
+++ b/meguru/core/google_api.py
@@ -1,0 +1,175 @@
+"""Thin wrapper around the Google Maps/Places HTTP APIs."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Tuple
+
+import requests
+
+from meguru.core import db
+from meguru.schemas import Place
+
+_GOOGLE_MAPS_BASE_URL = "https://maps.googleapis.com/maps/api"
+_DEFAULT_TIMEOUT = float(os.getenv("GOOGLE_MAPS_TIMEOUT", "10"))
+
+
+class GoogleMapsError(RuntimeError):
+    """Raised when the Google Maps API returns an unexpected response."""
+
+
+def _api_key() -> str:
+    api_key = os.getenv("GOOGLE_MAPS_API_KEY")
+    if not api_key:
+        raise RuntimeError("GOOGLE_MAPS_API_KEY environment variable is not set")
+    return api_key
+
+
+def _request(path: str, params: Dict[str, object]) -> Dict[str, object]:
+    params = {**params, "key": _api_key()}
+    response = requests.get(
+        f"{_GOOGLE_MAPS_BASE_URL.rstrip('/')}/{path.lstrip('/')}",
+        params=params,
+        timeout=_DEFAULT_TIMEOUT,
+    )
+    response.raise_for_status()
+    data = response.json()
+    status = data.get("status")
+    if status and status not in {"OK", "ZERO_RESULTS"}:
+        message = data.get("error_message") or status
+        raise GoogleMapsError(f"Google Maps API error: {message}")
+    return data
+
+
+def find_places(query: str, location_bias: Optional[tuple[float, float]] = None) -> List[Dict[str, object]]:
+    """Search for places using a free text query."""
+
+    params: Dict[str, object] = {"query": query}
+    if location_bias:
+        params["location"] = f"{location_bias[0]},{location_bias[1]}"
+        params["radius"] = os.getenv("GOOGLE_MAPS_SEARCH_RADIUS", "2000")
+    data = _request("place/textsearch/json", params)
+    return data.get("results", [])  # type: ignore[return-value]
+
+
+def _normalise_place(result: Dict[str, object], place_id: str) -> Dict[str, object]:
+    geometry = result.get("geometry") or {}
+    location = geometry.get("location") or {}
+    photos = result.get("photos") or []
+    photo_reference: Optional[str] = None
+    if isinstance(photos, list) and photos:
+        first_photo = photos[0] or {}
+        if isinstance(first_photo, dict):
+            photo_reference = first_photo.get("photo_reference")  # type: ignore[assignment]
+
+    raw_types = result.get("types") or []
+    normalised_types: List[str]
+    if isinstance(raw_types, list):
+        normalised_types = [str(item) for item in raw_types]
+    elif raw_types:
+        normalised_types = [str(raw_types)]
+    else:
+        normalised_types = []
+
+    place = Place(
+        place_id=result.get("place_id") or place_id,
+        name=result.get("name") or "",
+        formatted_address=result.get("formatted_address") or result.get("vicinity"),
+        latitude=location.get("lat") if isinstance(location, dict) else None,
+        longitude=location.get("lng") if isinstance(location, dict) else None,
+        rating=result.get("rating"),
+        user_ratings_total=result.get("user_ratings_total"),
+        types=normalised_types,
+        price_level=result.get("price_level"),
+        business_status=result.get("business_status"),
+        website=result.get("website"),
+        phone_number=(
+            result.get("formatted_phone_number") or result.get("international_phone_number")
+        ),
+        google_maps_url=result.get("url"),
+        photo_reference=photo_reference,
+    )
+    return place.model_dump()
+
+
+def _place_ttl_hours() -> float:
+    ttl_env = os.getenv("PLACE_TTL_HOURS")
+    if not ttl_env:
+        return 24.0
+    try:
+        return float(ttl_env)
+    except ValueError:
+        return 24.0
+
+
+def place_details(place_id: str) -> Dict[str, object]:
+    """Return the normalised details for a Google Place, using a database cache."""
+
+    connection = db.get_connection()
+    try:
+        db.ensure_cache_table(connection)
+        cached = db.get_cache_entry(connection, place_id)
+        ttl = timedelta(hours=_place_ttl_hours())
+        if cached:
+            cached_value, updated_at = cached
+            if not isinstance(updated_at, datetime):
+                raise GoogleMapsError("Invalid cache entry: updated_at is not a datetime")
+            if updated_at.tzinfo is None:
+                updated_at = updated_at.replace(tzinfo=timezone.utc)
+            if datetime.now(timezone.utc) - updated_at <= ttl:
+                return cached_value
+
+        details_fields = [
+            "place_id",
+            "name",
+            "formatted_address",
+            "geometry/location",
+            "rating",
+            "user_ratings_total",
+            "types",
+            "price_level",
+            "business_status",
+            "website",
+            "formatted_phone_number",
+            "international_phone_number",
+            "url",
+            "photos",
+        ]
+        data = _request(
+            "place/details/json",
+            {"place_id": place_id, "fields": ",".join(details_fields)},
+        )
+        result = data.get("result")
+        if not isinstance(result, dict):
+            raise GoogleMapsError("Place details response did not contain a result")
+        normalised = _normalise_place(result, place_id)
+        db.set_cache_entry(connection, place_id, normalised)
+        return normalised
+    finally:
+        connection.close()
+
+
+def distance_matrix(
+    origins: List[Tuple[float, float]],
+    destinations: List[Tuple[float, float]],
+    mode: str = "walking",
+) -> Dict[str, object]:
+    """Call the Google Distance Matrix API."""
+
+    origin_param = "|".join(f"{lat},{lng}" for lat, lng in origins)
+    destination_param = "|".join(f"{lat},{lng}" for lat, lng in destinations)
+    params = {
+        "origins": origin_param,
+        "destinations": destination_param,
+        "mode": mode,
+    }
+    return _request("distancematrix/json", params)
+
+
+__all__ = [
+    "GoogleMapsError",
+    "distance_matrix",
+    "find_places",
+    "place_details",
+]

--- a/meguru/schemas.py
+++ b/meguru/schemas.py
@@ -1,4 +1,31 @@
-"""Data schemas for the Meguru application.
+"""Data schemas for the Meguru application."""
 
-NOTE: Replace this placeholder with the provided schemas definition.
-"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Place(BaseModel):
+    """Normalised representation of a Google Place."""
+
+    place_id: str
+    name: str
+    formatted_address: Optional[str] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    rating: Optional[float] = None
+    user_ratings_total: Optional[int] = None
+    types: List[str] = Field(default_factory=list)
+    price_level: Optional[int] = None
+    business_status: Optional[str] = None
+    website: Optional[str] = None
+    phone_number: Optional[str] = None
+    google_maps_url: Optional[str] = None
+    photo_reference: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+__all__ = ["Place"]

--- a/meguru/tests/test_google_api.py
+++ b/meguru/tests/test_google_api.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+import pytest
+
+from meguru.core import db, google_api
+from meguru.schemas import Place
+
+
+class FakeCursor:
+    def __init__(self, rows: List[Dict[str, Any]], actions: List[Any]):
+        self._rows = rows
+        self._actions = actions
+        self._last_query = ""
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - signature required by context manager protocol
+        return None
+
+    def execute(self, query: str, params: Any = None) -> None:
+        self._last_query = query
+        self._actions.append(("execute", query, params))
+
+    def fetchone(self) -> Dict[str, Any] | None:
+        if self._rows:
+            return self._rows.pop(0)
+        return None
+
+
+class FakeConnection:
+    def __init__(self, rows: List[Dict[str, Any]] | None = None):
+        self.rows = list(rows or [])
+        self.actions: List[Any] = []
+        self.closed = False
+
+    def cursor(self, *args: Any, **kwargs: Any) -> FakeCursor:
+        return FakeCursor(self.rows, self.actions)
+
+    def commit(self) -> None:
+        self.actions.append("commit")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _new_place(name: str) -> Dict[str, Any]:
+    return Place(
+        place_id="place_123",
+        name=name,
+        formatted_address="123 Example Street",
+        latitude=1.23,
+        longitude=4.56,
+        rating=4.7,
+        user_ratings_total=100,
+        types=["restaurant"],
+        price_level=2,
+        business_status="OPERATIONAL",
+        website="https://example.com",
+        phone_number="123",
+        google_maps_url="https://maps.google.com/?cid=123",
+    ).model_dump()
+
+
+def test_place_details_returns_cached_value_when_not_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    cached_place = _new_place("Cached")
+    fake_conn = FakeConnection(
+        rows=[{"value": cached_place, "updated_at": datetime.now(timezone.utc)}]
+    )
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", "key")
+    monkeypatch.setenv("PLACE_TTL_HOURS", "24")
+    monkeypatch.setattr(db, "get_connection", lambda: fake_conn)
+    monkeypatch.setattr(google_api, "_request", lambda *args, **kwargs: pytest.fail("API should not be called"))
+
+    result = google_api.place_details("place_123")
+
+    assert result == cached_place
+    assert fake_conn.closed is True
+
+
+def test_place_details_calls_api_when_cache_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_conn = FakeConnection(rows=[])
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", "key")
+    monkeypatch.setenv("PLACE_TTL_HOURS", "24")
+    monkeypatch.setattr(db, "get_connection", lambda: fake_conn)
+
+    new_payload = {
+        "status": "OK",
+        "result": {
+            "place_id": "place_123",
+            "name": "Fresh Place",
+            "formatted_address": "456 New Street",
+            "geometry": {"location": {"lat": 9.87, "lng": 6.54}},
+            "rating": 4.9,
+            "user_ratings_total": 10,
+            "types": ["cafe"],
+            "price_level": 3,
+            "business_status": "OPERATIONAL",
+            "website": "https://fresh.example.com",
+            "formatted_phone_number": "+1 555-0100",
+            "url": "https://maps.google.com/?cid=456",
+        },
+    }
+
+    recorded_cache: Dict[str, Any] = {}
+
+    def fake_set_cache(connection: FakeConnection, key: str, value: Dict[str, Any]) -> None:
+        recorded_cache["key"] = key
+        recorded_cache["value"] = value
+
+    monkeypatch.setattr(db, "set_cache_entry", fake_set_cache)
+    monkeypatch.setattr(google_api, "_request", lambda *args, **kwargs: new_payload)
+
+    result = google_api.place_details("place_123")
+
+    expected = Place(
+        place_id="place_123",
+        name="Fresh Place",
+        formatted_address="456 New Street",
+        latitude=9.87,
+        longitude=6.54,
+        rating=4.9,
+        user_ratings_total=10,
+        types=["cafe"],
+        price_level=3,
+        business_status="OPERATIONAL",
+        website="https://fresh.example.com",
+        phone_number="+1 555-0100",
+        google_maps_url="https://maps.google.com/?cid=456",
+        photo_reference=None,
+    ).model_dump()
+
+    assert result == expected
+    assert recorded_cache["key"] == "place_123"
+    assert recorded_cache["value"] == expected
+    assert fake_conn.closed is True
+
+
+def test_place_details_refreshes_cache_when_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    cached_place = _new_place("Old")
+    fake_conn = FakeConnection(
+        rows=[
+            {
+                "value": cached_place,
+                "updated_at": datetime.now(timezone.utc) - timedelta(hours=48),
+            }
+        ]
+    )
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", "key")
+    monkeypatch.setenv("PLACE_TTL_HOURS", "1")
+    monkeypatch.setattr(db, "get_connection", lambda: fake_conn)
+
+    new_payload = {
+        "status": "OK",
+        "result": {
+            "place_id": "place_123",
+            "name": "Updated Place",
+            "formatted_address": "456 New Street",
+            "geometry": {"location": {"lat": 2.0, "lng": 3.0}},
+            "rating": 4.5,
+            "user_ratings_total": 25,
+            "types": ["museum"],
+            "price_level": 1,
+            "business_status": "OPERATIONAL",
+            "website": "https://updated.example.com",
+            "international_phone_number": "+81 90-0000-0000",
+            "url": "https://maps.google.com/?cid=789",
+        },
+    }
+
+    recorded_cache: Dict[str, Any] = {}
+
+    def fake_set_cache(connection: FakeConnection, key: str, value: Dict[str, Any]) -> None:
+        recorded_cache["key"] = key
+        recorded_cache["value"] = value
+
+    monkeypatch.setattr(db, "set_cache_entry", fake_set_cache)
+    monkeypatch.setattr(google_api, "_request", lambda *args, **kwargs: new_payload)
+
+    result = google_api.place_details("place_123")
+
+    expected = Place(
+        place_id="place_123",
+        name="Updated Place",
+        formatted_address="456 New Street",
+        latitude=2.0,
+        longitude=3.0,
+        rating=4.5,
+        user_ratings_total=25,
+        types=["museum"],
+        price_level=1,
+        business_status="OPERATIONAL",
+        website="https://updated.example.com",
+        phone_number="+81 90-0000-0000",
+        google_maps_url="https://maps.google.com/?cid=789",
+        photo_reference=None,
+    ).model_dump()
+
+    assert result == expected
+    assert recorded_cache["key"] == "place_123"
+    assert recorded_cache["value"] == expected
+    assert fake_conn.closed is True


### PR DESCRIPTION
## Summary
- add a Google Maps API wrapper supporting place search, details, and distance matrix calls
- introduce a Postgres cache helper that gracefully handles optional psycopg2 availability
- normalize the Place schema and add unit tests for cache behaviour and TTL handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccb4c6ffac83289bd909d1afad9f7f