### PR TITLE
Implement LLM-backed travel agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.py[cod]
 .pytest_cache/
 .DS_Store
+node_modules/

--- a/meguru/agents/__init__.py
+++ b/meguru/agents/__init__.py
@@ -1,0 +1,84 @@
+"""Shared utilities for Meguru's LLM-backed agents."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, datetime
+from typing import Any, Optional, Sequence, Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from meguru.core.llm import llm_json
+
+T = TypeVar("T", bound=BaseModel)
+
+
+DEFAULT_AGENT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+
+class AgentExecutionError(RuntimeError):
+    """Raised when an agent cannot return a valid payload."""
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, set):
+        return sorted(value)
+    return value
+
+
+def format_prompt_data(data: Any) -> str:
+    """Render arbitrary python data for inclusion in an LLM prompt."""
+
+    return json.dumps(data, indent=2, default=_json_default)
+
+
+def call_llm_and_validate(
+    *,
+    schema: Type[T],
+    prompt: str,
+    system_prompt: str,
+    prompt_version: str,
+    model: Optional[str] = None,
+    stop: Optional[Sequence[str]] = None,
+) -> T:
+    """Call the shared LLM helper and validate the JSON payload."""
+
+    data = llm_json(
+        prompt=prompt,
+        system=system_prompt,
+        model=model or DEFAULT_AGENT_MODEL,
+        stop=stop,
+        prompt_version=prompt_version,
+    )
+    try:
+        return schema.model_validate(data)
+    except ValidationError as exc:  # pragma: no cover - exercised in tests via failure path
+        raise AgentExecutionError(
+            f"LLM response could not be validated as {schema.__name__}: {exc}"
+        ) from exc
+
+
+from .intake import IntakeAgent
+from .planner import PlannerAgent
+from .refiner import RefinerAgent
+from .researcher import ResearcherAgent
+from .summary import SummaryAgent
+from .taste import TasteAgent
+
+__all__ = [
+    "AgentExecutionError",
+    "DEFAULT_AGENT_MODEL",
+    "IntakeAgent",
+    "PlannerAgent",
+    "RefinerAgent",
+    "ResearcherAgent",
+    "SummaryAgent",
+    "TasteAgent",
+    "call_llm_and_validate",
+    "format_prompt_data",
+]

--- a/meguru/agents/intake.py
+++ b/meguru/agents/intake.py
@@ -1,0 +1,66 @@
+"""Agent responsible for translating intake data into a :class:`TripIntent`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence
+
+from meguru.agents import DEFAULT_AGENT_MODEL, call_llm_and_validate, format_prompt_data
+from meguru.schemas import TripIntent
+
+
+class IntakeAgent:
+    """Normalises raw intake information into a :class:`TripIntent`."""
+
+    system_prompt = (
+        "You are an expert travel planner capturing the intent for an upcoming trip. "
+        "Only respond with a JSON object that matches the TripIntent schema."
+    )
+    prompt_version = "intake.v1"
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        stop: Optional[Sequence[str]] = None,
+    ) -> None:
+        self.model = model or DEFAULT_AGENT_MODEL
+        self.stop = stop
+
+    def run(
+        self,
+        *,
+        free_text: Optional[str] = None,
+        wizard_fields: Optional[Dict[str, Any]] = None,
+    ) -> TripIntent:
+        """Return a structured :class:`TripIntent` from user-provided data."""
+
+        if not free_text and not wizard_fields:
+            raise ValueError("Either free_text or wizard_fields must be provided.")
+
+        prompt_payload = {
+            "free_text": free_text,
+            "wizard_fields": wizard_fields or {},
+        }
+
+        prompt = (
+            "Extract a complete TripIntent from the following intake information.\n"
+            "Fill in sensible defaults where details are missing, keeping interests aligned\n"
+            "to the traveller's requests.\n"
+            "\n"
+            "# Intake Data\n"
+            f"{format_prompt_data(prompt_payload)}\n"
+            "\n"
+            "Ensure destination, dates, pace, interests, and any constraints are clearly captured."
+        )
+
+        return call_llm_and_validate(
+            schema=TripIntent,
+            prompt=prompt,
+            system_prompt=self.system_prompt,
+            prompt_version=self.prompt_version,
+            model=self.model,
+            stop=self.stop,
+        )
+
+
+__all__ = ["IntakeAgent"]

--- a/meguru/agents/planner.py
+++ b/meguru/agents/planner.py
@@ -1,0 +1,93 @@
+"""Agent that assembles a multi-day itinerary from curated places."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence
+
+from meguru.agents import DEFAULT_AGENT_MODEL, call_llm_and_validate, format_prompt_data
+from meguru.schemas import (
+    Itinerary,
+    Place,
+    ResearchCorpus,
+    TasteProfile,
+    TripIntent,
+    attach_places,
+)
+
+
+class PlannerAgent:
+    """Produces a structured itinerary using researched places and traveller tastes."""
+
+    system_prompt = (
+        "You are a meticulous travel planner. Create a paced itinerary that respects "
+        "opening hours and reasonable travel distances. Respond with JSON conforming to the "
+        "Itinerary schema."
+    )
+    prompt_version = "planner.v1"
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        stop: Optional[Sequence[str]] = None,
+    ) -> None:
+        self.model = model or DEFAULT_AGENT_MODEL
+        self.stop = stop
+
+    def _build_place_lookup(
+        self, corpus: ResearchCorpus, taste: TasteProfile
+    ) -> Dict[str, Place]:
+        lookup: Dict[str, Place] = {}
+        for item in corpus.items():
+            if item.place:
+                lookup[item.place.place_id] = item.place
+        for ranked in taste.items():
+            if ranked.place:
+                lookup[ranked.place.place_id] = ranked.place
+        return lookup
+
+    def run(
+        self,
+        trip_intent: TripIntent,
+        taste_profile: TasteProfile,
+        corpus: ResearchCorpus,
+    ) -> Itinerary:
+        """Return an :class:`Itinerary` based on the traveller preferences."""
+
+        prompt_payload = {
+            "trip_intent": trip_intent,
+            "taste_profile": taste_profile,
+            "research": corpus,
+        }
+
+        prompt = (
+            "Design a day-by-day itinerary that balances activity pace, observes opening hours, "
+            "and minimises unnecessary backtracking.\n"
+            "Include descriptive summaries for each day and ensure activities map back to the "
+            "ranked places when relevant.\n"
+            "\n"
+            "# Planning Context\n"
+            f"{format_prompt_data(prompt_payload)}\n"
+            "\n"
+            "Output must validate against the Itinerary schema."
+        )
+
+        itinerary = call_llm_and_validate(
+            schema=Itinerary,
+            prompt=prompt,
+            system_prompt=self.system_prompt,
+            prompt_version=self.prompt_version,
+            model=self.model,
+            stop=self.stop,
+        )
+
+        if not itinerary.destination:
+            itinerary.destination = trip_intent.destination
+
+        place_lookup = self._build_place_lookup(corpus, taste_profile)
+        attach_places(place_lookup=place_lookup, itinerary=itinerary)
+
+        return itinerary
+
+
+__all__ = ["PlannerAgent"]

--- a/meguru/agents/refiner.py
+++ b/meguru/agents/refiner.py
@@ -1,0 +1,81 @@
+"""Agent that refines an itinerary based on user feedback."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence
+
+from meguru.agents import DEFAULT_AGENT_MODEL, call_llm_and_validate, format_prompt_data
+from meguru.schemas import Itinerary, Place, RefinerRequest, RefinerResponse, attach_places
+
+
+class RefinerAgent:
+    """Adjusts a specific itinerary day in response to traveller feedback."""
+
+    system_prompt = (
+        "You refine travel plans. Update the specified day to address the traveller's feedback "
+        "while keeping the overall itinerary coherent. Only return JSON that conforms to the "
+        "RefinerResponse schema."
+    )
+    prompt_version = "refiner.v1"
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        stop: Optional[Sequence[str]] = None,
+    ) -> None:
+        self.model = model or DEFAULT_AGENT_MODEL
+        self.stop = stop
+
+    def _build_place_lookup(self, *itineraries: Itinerary) -> Dict[str, Place]:
+        lookup: Dict[str, Place] = {}
+        for itinerary in itineraries:
+            for event in itinerary.all_events():
+                if event.place:
+                    lookup[event.place.place_id] = event.place
+        return lookup
+
+    def run(
+        self,
+        request: RefinerRequest,
+        *,
+        additional_places: Optional[Dict[str, Place]] = None,
+    ) -> RefinerResponse:
+        """Return a :class:`RefinerResponse` honouring the provided feedback."""
+
+        prompt_payload = {
+            "request": request,
+        }
+
+        prompt = (
+            "Using the supplied feedback, adjust only the specified day of the itinerary.\n"
+            "Maintain logical pacing, avoid duplicate activities across the trip, and respect "
+            "any constraints.\n"
+            "\n"
+            "# Refinement Context\n"
+            f"{format_prompt_data(prompt_payload)}\n"
+            "\n"
+            "Return JSON validating against the RefinerResponse schema."
+        )
+
+        response = call_llm_and_validate(
+            schema=RefinerResponse,
+            prompt=prompt,
+            system_prompt=self.system_prompt,
+            prompt_version=self.prompt_version,
+            model=self.model,
+            stop=self.stop,
+        )
+
+        response.ensure_consistency(preferred_index=request.day_index)
+
+        lookup = self._build_place_lookup(request.itinerary, response.itinerary)
+        if additional_places:
+            lookup.update(additional_places)
+
+        attach_places(place_lookup=lookup, itinerary=response.itinerary)
+
+        return response
+
+
+__all__ = ["RefinerAgent"]

--- a/meguru/agents/researcher.py
+++ b/meguru/agents/researcher.py
@@ -1,0 +1,132 @@
+"""Agent for researching candidate places using Google Maps data."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Optional
+
+from meguru.agents import DEFAULT_AGENT_MODEL, call_llm_and_validate, format_prompt_data
+from meguru.core import google_api
+from meguru.schemas import Place, ResearchCorpus, TripIntent, attach_places
+
+
+class ResearcherAgent:
+    """Curates lodging, dining, and experience options for a trip."""
+
+    system_prompt = (
+        "You are a travel researcher. Categorise each place into the correct bucket "
+        "and describe why it suits the trip. Only emit JSON that matches the ResearchCorpus schema."
+    )
+    prompt_version = "researcher.v1"
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        max_results_per_category: int = 5,
+    ) -> None:
+        self.model = model or DEFAULT_AGENT_MODEL
+        self.max_results_per_category = max_results_per_category
+
+    def _build_queries(self, trip_intent: TripIntent) -> Dict[str, List[str]]:
+        destination = trip_intent.destination
+        interests = trip_intent.interests or []
+
+        lodging_queries = [f"best hotels in {destination}", f"unique stays {destination}"]
+        dining_queries = [f"top restaurants {destination}", f"must try food {destination}"]
+
+        experience_queries = [f"things to do {destination}"]
+        for interest in interests:
+            experience_queries.append(f"{destination} {interest}")
+
+        return {
+            "lodgings": lodging_queries,
+            "dining": dining_queries,
+            "experiences": experience_queries,
+        }
+
+    def _gather_places(
+        self, queries: Dict[str, List[str]]
+    ) -> Dict[str, List[Dict[str, object]]]:
+        aggregated: Dict[str, List[Dict[str, object]]] = defaultdict(list)
+        seen: set[str] = set()
+
+        for category, category_queries in queries.items():
+            for query in category_queries:
+                results = google_api.find_places(query)
+                for result in results:
+                    place_id = result.get("place_id") if isinstance(result, dict) else None
+                    if not place_id or place_id in seen:
+                        continue
+
+                    seen.add(place_id)
+                    details = google_api.place_details(place_id)
+                    aggregated[category].append(details)
+
+                    if len(aggregated[category]) >= self.max_results_per_category:
+                        break
+                if len(aggregated[category]) >= self.max_results_per_category:
+                    break
+
+        return aggregated
+
+    def _format_place_details(self, places: Iterable[Dict[str, object]]) -> List[Dict[str, object]]:
+        formatted: List[Dict[str, object]] = []
+        for place in places:
+            try:
+                formatted.append(Place.model_validate(place).model_dump())
+            except Exception:
+                # If validation fails we still include the raw payload for the LLM to consider.
+                formatted.append(place)
+        return formatted
+
+    def run(self, trip_intent: TripIntent) -> ResearchCorpus:
+        """Return a :class:`ResearchCorpus` tailored to the provided :class:`TripIntent`."""
+
+        if not trip_intent.destination:
+            raise ValueError("Trip intent must include a destination to research.")
+
+        queries = self._build_queries(trip_intent)
+        raw_places = self._gather_places(queries)
+
+        prompt_payload = {
+            "trip_intent": trip_intent,
+            "places": {
+                category: self._format_place_details(details)
+                for category, details in raw_places.items()
+            },
+        }
+
+        prompt = (
+            "Given the following trip intent and researched Google Places data, "
+            "select the most relevant options for lodging, dining, and experiences.\n"
+            "Provide concise summaries, highlights, and tags that connect the place to "
+            "the traveller's stated interests.\n"
+            "\n"
+            "# Research Context\n"
+            f"{format_prompt_data(prompt_payload)}\n"
+            "\n"
+            "Respond with JSON adhering to the ResearchCorpus schema."
+        )
+
+        corpus = call_llm_and_validate(
+            schema=ResearchCorpus,
+            prompt=prompt,
+            system_prompt=self.system_prompt,
+            prompt_version=self.prompt_version,
+            model=self.model,
+        )
+
+        place_lookup = {
+            place_data["place_id"]: Place.model_validate(place_data)
+            for category_places in raw_places.values()
+            for place_data in category_places
+            if isinstance(place_data, dict) and place_data.get("place_id")
+        }
+
+        attach_places(place_lookup=place_lookup, research_items=corpus.items())
+
+        return corpus
+
+
+__all__ = ["ResearcherAgent"]

--- a/meguru/agents/summary.py
+++ b/meguru/agents/summary.py
@@ -1,0 +1,55 @@
+"""Agent that converts an itinerary into a concise HTML summary."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from meguru.agents import DEFAULT_AGENT_MODEL, call_llm_and_validate, format_prompt_data
+from meguru.schemas import Itinerary, ItinerarySummary
+
+
+class SummaryAgent:
+    """Produces a user-friendly HTML overview of an itinerary."""
+
+    system_prompt = (
+        "You are a copywriter for a travel service. Summarise the itinerary in an engaging "
+        "yet concise way using HTML paragraphs and lists. Respond with JSON containing only an "
+        "'html' field."
+    )
+    prompt_version = "summary.v1"
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        stop: Optional[Sequence[str]] = None,
+    ) -> None:
+        self.model = model or DEFAULT_AGENT_MODEL
+        self.stop = stop
+
+    def run(self, itinerary: Itinerary) -> str:
+        """Return an HTML summary for the supplied itinerary."""
+
+        prompt = (
+            "Create a short but vivid summary of the itinerary suitable for a trip overview.\n"
+            "Use friendly language, highlight each day's focus, and keep the output under 1200 characters.\n"
+            "\n"
+            "# Itinerary\n"
+            f"{format_prompt_data(itinerary)}\n"
+            "\n"
+            "Respond with JSON containing a single 'html' string."
+        )
+
+        summary = call_llm_and_validate(
+            schema=ItinerarySummary,
+            prompt=prompt,
+            system_prompt=self.system_prompt,
+            prompt_version=self.prompt_version,
+            model=self.model,
+            stop=self.stop,
+        )
+
+        return summary.html
+
+
+__all__ = ["SummaryAgent"]

--- a/meguru/agents/taste.py
+++ b/meguru/agents/taste.py
@@ -1,0 +1,71 @@
+"""Agent that scores researched places to build a taste profile."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence
+
+from meguru.agents import DEFAULT_AGENT_MODEL, call_llm_and_validate, format_prompt_data
+from meguru.schemas import Place, ResearchCorpus, TasteProfile, TripIntent, attach_places
+
+
+class TasteAgent:
+    """Turns researched places into prioritised recommendations."""
+
+    system_prompt = (
+        "You are a seasoned travel curator. Score the researched places and explain why "
+        "they align with the traveller's interests. Respond with JSON that matches the "
+        "TasteProfile schema."
+    )
+    prompt_version = "taste.v1"
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        stop: Optional[Sequence[str]] = None,
+    ) -> None:
+        self.model = model or DEFAULT_AGENT_MODEL
+        self.stop = stop
+
+    def _build_place_lookup(self, corpus: ResearchCorpus) -> Dict[str, Place]:
+        lookup: Dict[str, Place] = {}
+        for item in corpus.items():
+            if item.place:
+                lookup[item.place.place_id] = item.place
+        return lookup
+
+    def run(self, trip_intent: TripIntent, corpus: ResearchCorpus) -> TasteProfile:
+        """Return a :class:`TasteProfile` aligned with the :class:`TripIntent`."""
+
+        prompt_payload = {
+            "trip_intent": trip_intent,
+            "research": corpus,
+        }
+
+        prompt = (
+            "Given the trip intent and researched options, rank the places.\n"
+            "Provide scores between 0 and 1, articulate rationales, and ensure the tags "
+            "map back to the traveller's stated interests or constraints.\n"
+            "\n"
+            "# Context\n"
+            f"{format_prompt_data(prompt_payload)}\n"
+            "\n"
+            "Return JSON that validates against the TasteProfile schema."
+        )
+
+        profile = call_llm_and_validate(
+            schema=TasteProfile,
+            prompt=prompt,
+            system_prompt=self.system_prompt,
+            prompt_version=self.prompt_version,
+            model=self.model,
+            stop=self.stop,
+        )
+
+        place_lookup = self._build_place_lookup(corpus)
+        attach_places(place_lookup=place_lookup, ranked_items=profile.items())
+
+        return profile
+
+
+__all__ = ["TasteAgent"]

--- a/meguru/schemas.py
+++ b/meguru/schemas.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from datetime import date, time
+from typing import Dict, Iterable, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, PositiveInt
 
 
 class Place(BaseModel):
@@ -28,4 +29,252 @@ class Place(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-__all__ = ["Place"]
+class Traveler(BaseModel):
+    """A person travelling on the trip."""
+
+    name: Optional[str] = None
+    age: Optional[PositiveInt] = None
+    notes: Optional[str] = None
+
+
+class TripIntent(BaseModel):
+    """Normalised intent gathered from the intake flow."""
+
+    destination: str
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    duration_days: Optional[PositiveInt] = None
+    travelers: List[Traveler] = Field(default_factory=list)
+    travel_pace: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("travel_pace", "pace"),
+    )
+    budget: Optional[str] = None
+    interests: List[str] = Field(default_factory=list)
+    must_do: List[str] = Field(default_factory=list)
+    exclusions: List[str] = Field(default_factory=list)
+    dining_preferences: List[str] = Field(default_factory=list)
+    lodging_preferences: List[str] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ResearchItem(BaseModel):
+    """A researched place annotated for later stages."""
+
+    place_id: str
+    place: Optional[Place] = None
+    summary: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("summary", "description"),
+    )
+    highlights: List[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("highlights", "reasons", "why"),
+    )
+    suitability: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("suitability", "fit"),
+    )
+    tags: List[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("tags", "themes"),
+    )
+
+
+class ResearchCorpus(BaseModel):
+    """Curated set of researched places grouped by theme."""
+
+    lodgings: List[ResearchItem] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("lodgings", "lodging", "stays"),
+    )
+    dining: List[ResearchItem] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("dining", "restaurants", "food"),
+    )
+    experiences: List[ResearchItem] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("experiences", "activities", "things_to_do"),
+    )
+    other: List[ResearchItem] = Field(default_factory=list)
+
+    def items(self) -> Iterable[ResearchItem]:
+        """Iterate over every research item in the corpus."""
+
+        for bucket in (self.lodgings, self.dining, self.experiences, self.other):
+            yield from bucket
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class RankedItem(BaseModel):
+    """A scored place surfaced for travellers."""
+
+    place_id: str
+    score: float = Field(
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("score", "rating"),
+    )
+    rationale: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("rationale", "reason"),
+    )
+    tags: List[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("tags", "themes"),
+    )
+    category: Optional[str] = None
+    place: Optional[Place] = None
+
+
+class TasteProfile(BaseModel):
+    """Prioritised list of places aligned to a trip intent."""
+
+    top_picks: List[RankedItem] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("top_picks", "primary", "highlights"),
+    )
+    backups: List[RankedItem] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("backups", "secondary", "alternatives"),
+    )
+    wildcard: List[RankedItem] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("wildcard", "wildcards", "extras"),
+    )
+
+    def items(self) -> Iterable[RankedItem]:
+        for bucket in (self.top_picks, self.backups, self.wildcard):
+            yield from bucket
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ItineraryEvent(BaseModel):
+    """An individual scheduled activity inside an itinerary day."""
+
+    title: str
+    description: Optional[str] = None
+    place_id: Optional[str] = None
+    start_time: Optional[time] = None
+    end_time: Optional[time] = None
+    tags: List[str] = Field(default_factory=list)
+    place: Optional[Place] = None
+
+
+class DayPlan(BaseModel):
+    """Plan for a single day of travel."""
+
+    label: Optional[str] = None
+    date: Optional[date] = None
+    summary: Optional[str] = None
+    pace: Optional[str] = None
+    events: List[ItineraryEvent] = Field(default_factory=list)
+
+
+class Itinerary(BaseModel):
+    """Structured multi-day trip plan."""
+
+    destination: str
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    days: List[DayPlan] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+    def all_events(self) -> Iterable[ItineraryEvent]:
+        for day in self.days:
+            yield from day.events
+
+
+class ItinerarySummary(BaseModel):
+    """Short HTML summary for presenting an itinerary."""
+
+    html: str
+
+
+class RefinerRequest(BaseModel):
+    """Request payload for the itinerary refiner agent."""
+
+    itinerary: Itinerary
+    day_index: int = Field(ge=0)
+    feedback: str
+    additional_constraints: Optional[str] = None
+
+
+class RefinerResponse(BaseModel):
+    """Response returned by the itinerary refiner agent."""
+
+    itinerary: Itinerary
+    updated_day: DayPlan
+    notes: Optional[str] = None
+
+    def ensure_consistency(self, preferred_index: Optional[int] = None) -> None:
+        """Ensure the updated day is placed within the itinerary."""
+
+        if preferred_index is not None:
+            while len(self.itinerary.days) <= preferred_index:
+                self.itinerary.days.append(DayPlan())
+            self.itinerary.days[preferred_index] = self.updated_day
+            return
+
+        for idx, day in enumerate(self.itinerary.days):
+            if day.date and self.updated_day.date and day.date == self.updated_day.date:
+                self.itinerary.days[idx] = self.updated_day
+                return
+            if day.label and self.updated_day.label and day.label == self.updated_day.label:
+                self.itinerary.days[idx] = self.updated_day
+                return
+
+        self.itinerary.days.append(self.updated_day)
+
+
+def attach_places(
+    *,
+    place_lookup: Dict[str, Place],
+    research_items: Iterable[ResearchItem] | None = None,
+    ranked_items: Iterable[RankedItem] | None = None,
+    itinerary: Itinerary | None = None,
+) -> None:
+    """Attach :class:`Place` instances to objects that reference a place id."""
+
+    if research_items:
+        for item in research_items:
+            if isinstance(item.place, dict):
+                item.place = Place.model_validate(item.place)
+            if item.place is None and item.place_id in place_lookup:
+                item.place = place_lookup[item.place_id]
+
+    if ranked_items:
+        for item in ranked_items:
+            if isinstance(item.place, dict):
+                item.place = Place.model_validate(item.place)
+            if item.place is None and item.place_id in place_lookup:
+                item.place = place_lookup[item.place_id]
+
+    if itinerary:
+        for event in itinerary.all_events():
+            if isinstance(event.place, dict):
+                event.place = Place.model_validate(event.place)
+            if event.place is None and event.place_id and event.place_id in place_lookup:
+                event.place = place_lookup[event.place_id]
+
+
+__all__ = [
+    "DayPlan",
+    "Itinerary",
+    "ItineraryEvent",
+    "ItinerarySummary",
+    "Place",
+    "RankedItem",
+    "RefinerRequest",
+    "RefinerResponse",
+    "ResearchCorpus",
+    "ResearchItem",
+    "TasteProfile",
+    "Traveler",
+    "TripIntent",
+    "attach_places",
+]


### PR DESCRIPTION
## Summary
- expand the shared schemas with trip intent, research, taste, itinerary, and refiner models plus helpers for attaching place data
- add common agent utilities and expose the concrete travel agents
- implement intake, researcher, taste, planner, summary, and refiner agents that call the JSON-enforced LLM helper
- ignore node_modules to keep the repo clean

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccb65bffc48328972352004baaa32c