### PR TITLE
Add orchestrated trip pipeline with caching and tests

### DIFF
--- a/meguru/tests/test_trip_pipeline.py
+++ b/meguru/tests/test_trip_pipeline.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Dict, Optional
+
+import pytest
+
+from meguru.schemas import (
+    DayPlan,
+    Itinerary,
+    ItineraryEvent,
+    RankedItem,
+    ResearchCorpus,
+    ResearchItem,
+    TasteProfile,
+    TripIntent,
+)
+from meguru.workflows import trip_pipeline
+
+
+SUMMARY_HTML = "<p>Kyoto adventure</p>"
+
+
+def _build_research_corpus() -> ResearchCorpus:
+    return ResearchCorpus(
+        lodgings=[ResearchItem(place_id="stay-1")],
+        dining=[ResearchItem(place_id="dine-1")],
+        experiences=[
+            ResearchItem(place_id="exp-1"),
+            ResearchItem(place_id="exp-2"),
+            ResearchItem(place_id="exp-3"),
+        ],
+    )
+
+
+def _build_taste_profile() -> TasteProfile:
+    return TasteProfile(
+        top_picks=[
+            RankedItem(place_id="exp-1", score=0.95),
+            RankedItem(place_id="exp-2", score=0.9),
+            RankedItem(place_id="dine-1", score=0.85),
+        ],
+        backups=[RankedItem(place_id="exp-3", score=0.6)],
+    )
+
+
+def _build_itinerary(destination: str) -> Itinerary:
+    return Itinerary(
+        destination=destination,
+        start_date=date(2024, 5, 1),
+        end_date=date(2024, 5, 3),
+        days=[
+            DayPlan(
+                label="Day 1",
+                events=[
+                    ItineraryEvent(title="Breakfast at cafe", place_id="dine-1"),
+                    ItineraryEvent(title="Morning walk", place_id="exp-1"),
+                    ItineraryEvent(title="Afternoon temple", place_id="exp-2"),
+                ],
+            ),
+            DayPlan(
+                label="Day 2",
+                events=[ItineraryEvent(title="Museum visit", place_id="exp-3")],
+            ),
+        ],
+    )
+
+
+def _patch_pipeline_agents(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    research_calls: Dict[str, int],
+    prompt_versions: Optional[Dict[str, str]] = None,
+) -> None:
+    prompt_versions = prompt_versions or {
+        "intake": "intake.stub",
+        "researcher": "researcher.stub",
+        "taste": "taste.stub",
+        "planner": "planner.stub",
+        "summary": "summary.stub",
+    }
+
+    class DummyIntakeAgent:
+        prompt_version = prompt_versions["intake"]
+
+        def __init__(self, *_, **__):
+            pass
+
+        def run(self, *, free_text=None, wizard_fields=None):  # pragma: no cover - defensive
+            raise AssertionError("Intake agent should not be invoked for structured intents")
+
+    class DummyResearcherAgent:
+        prompt_version = prompt_versions["researcher"]
+
+        def run(self, trip_intent: TripIntent) -> ResearchCorpus:
+            research_calls["count"] = research_calls.get("count", 0) + 1
+            return _build_research_corpus()
+
+    class DummyTasteAgent:
+        prompt_version = prompt_versions["taste"]
+
+        def run(self, trip_intent: TripIntent, corpus: ResearchCorpus) -> TasteProfile:
+            return _build_taste_profile()
+
+    class DummyPlannerAgent:
+        prompt_version = prompt_versions["planner"]
+
+        def run(
+            self,
+            trip_intent: TripIntent,
+            taste_profile: TasteProfile,
+            corpus: ResearchCorpus,
+        ) -> Itinerary:
+            return _build_itinerary(trip_intent.destination)
+
+    class DummySummaryAgent:
+        prompt_version = prompt_versions["summary"]
+
+        def run(self, itinerary: Itinerary) -> str:
+            return SUMMARY_HTML
+
+    monkeypatch.setattr(trip_pipeline, "IntakeAgent", DummyIntakeAgent)
+    monkeypatch.setattr(trip_pipeline, "ResearcherAgent", DummyResearcherAgent)
+    monkeypatch.setattr(trip_pipeline, "TasteAgent", DummyTasteAgent)
+    monkeypatch.setattr(trip_pipeline, "PlannerAgent", DummyPlannerAgent)
+    monkeypatch.setattr(trip_pipeline, "SummaryAgent", DummySummaryAgent)
+
+
+def test_run_trip_pipeline_returns_enriched_itinerary(monkeypatch: pytest.MonkeyPatch) -> None:
+    trip_pipeline.clear_research_cache()
+    research_calls: Dict[str, int] = {}
+    _patch_pipeline_agents(monkeypatch, research_calls=research_calls)
+
+    intent = TripIntent(destination="Kyoto", interests=["culture", "food"])
+
+    itinerary = trip_pipeline.run_trip_pipeline(intent)
+
+    assert itinerary.destination == "Kyoto"
+    assert itinerary.days, "Pipeline should return at least one day"
+    assert len(itinerary.days[0].events) >= 3
+    assert itinerary.notes == SUMMARY_HTML
+    assert research_calls["count"] == 1
+
+
+def test_research_cache_reuses_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    trip_pipeline.clear_research_cache()
+    research_calls: Dict[str, int] = {}
+    _patch_pipeline_agents(monkeypatch, research_calls=research_calls)
+
+    intent = TripIntent(destination="Kyoto")
+
+    trip_pipeline.run_trip_pipeline(intent)
+    assert research_calls["count"] == 1
+
+    trip_pipeline.run_trip_pipeline(intent)
+    assert research_calls["count"] == 1, "Researcher should not rerun when cache hits"
+
+    trip_pipeline.clear_research_cache()
+    trip_pipeline.run_trip_pipeline(intent)
+    assert research_calls["count"] == 2
+
+
+def test_pipeline_logs_include_prompt_versions(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    trip_pipeline.clear_research_cache()
+    research_calls: Dict[str, int] = {}
+    prompt_versions = {
+        "intake": "intake.test.v1",
+        "researcher": "researcher.test.v2",
+        "taste": "taste.test.v3",
+        "planner": "planner.test.v4",
+        "summary": "summary.test.v5",
+    }
+    _patch_pipeline_agents(
+        monkeypatch,
+        research_calls=research_calls,
+        prompt_versions=prompt_versions,
+    )
+
+    intent = TripIntent(destination="Kyoto")
+
+    with caplog.at_level(logging.INFO):
+        trip_pipeline.run_trip_pipeline(intent)
+
+    for stage, version in prompt_versions.items():
+        assert any(
+            f"[prompt_version={version}]" in record.getMessage()
+            for record in caplog.records
+        ), f"Expected prompt version {version} to be logged for stage {stage}"

--- a/meguru/workflows/__init__.py
+++ b/meguru/workflows/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow entry points for orchestrating Meguru agents."""
+
+from .trip_pipeline import clear_research_cache, run_trip_pipeline
+
+__all__ = ["run_trip_pipeline", "clear_research_cache"]

--- a/meguru/workflows/trip_pipeline.py
+++ b/meguru/workflows/trip_pipeline.py
@@ -1,0 +1,139 @@
+"""Orchestrates the end-to-end flow for generating a trip itinerary."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Dict, Optional
+
+from meguru.agents import (
+    IntakeAgent,
+    PlannerAgent,
+    ResearcherAgent,
+    SummaryAgent,
+    TasteAgent,
+)
+from meguru.schemas import Itinerary, ResearchCorpus, TasteProfile, TripIntent
+
+_LOGGER = logging.getLogger(__name__)
+
+_RESEARCH_CACHE: Dict[str, ResearchCorpus] = {}
+
+
+def _cache_key(intent: TripIntent) -> str:
+    """Return a stable cache key for a :class:`TripIntent`."""
+
+    dump = intent.model_dump(mode="json")
+    return json.dumps(dump, sort_keys=True)
+
+
+def _log_stage(stage: str, duration: float, prompt_version: str, *, cached: bool = False) -> None:
+    suffix = " (cache hit)" if cached else ""
+    _LOGGER.info(
+        "%s stage completed%s in %.2fs [prompt_version=%s]",
+        stage.capitalize(),
+        suffix,
+        duration,
+        prompt_version,
+    )
+
+
+def _log_stage_skipped(stage: str, reason: str, prompt_version: str) -> None:
+    _LOGGER.info(
+        "%s stage skipped: %s [prompt_version=%s]",
+        stage.capitalize(),
+        reason,
+        prompt_version,
+    )
+
+
+def clear_research_cache() -> None:
+    """Clear the in-memory cache used for research results."""
+
+    _RESEARCH_CACHE.clear()
+
+
+def _run_intake_if_needed(intent: TripIntent) -> TripIntent:
+    if intent.destination:
+        _log_stage_skipped(
+            "intake",
+            "Trip intent already structured",
+            IntakeAgent.prompt_version,
+        )
+        return intent
+
+    free_text = intent.notes.strip() if intent.notes else None
+    if not free_text:
+        raise ValueError("Trip intent must include a destination or raw notes for intake.")
+
+    start = time.perf_counter()
+    agent = IntakeAgent()
+    structured = agent.run(free_text=free_text)
+    _log_stage("intake", time.perf_counter() - start, agent.prompt_version)
+    return structured
+
+
+def _run_research(trip_intent: TripIntent) -> ResearchCorpus:
+    key = _cache_key(trip_intent)
+    cached = _RESEARCH_CACHE.get(key)
+    start = time.perf_counter()
+    if cached is not None:
+        _log_stage("researcher", time.perf_counter() - start, ResearcherAgent.prompt_version, cached=True)
+        return cached.model_copy(deep=True)
+
+    agent = ResearcherAgent()
+    corpus = agent.run(trip_intent)
+    _RESEARCH_CACHE[key] = corpus.model_copy(deep=True)
+    _log_stage("researcher", time.perf_counter() - start, agent.prompt_version)
+    return corpus
+
+
+def _run_taste(trip_intent: TripIntent, corpus: ResearchCorpus) -> TasteProfile:
+    start = time.perf_counter()
+    agent = TasteAgent()
+    taste_profile = agent.run(trip_intent, corpus)
+    _log_stage("taste", time.perf_counter() - start, agent.prompt_version)
+    return taste_profile
+
+
+def _run_planner(
+    trip_intent: TripIntent,
+    taste_profile: TasteProfile,
+    corpus: ResearchCorpus,
+) -> Itinerary:
+    start = time.perf_counter()
+    agent = PlannerAgent()
+    itinerary = agent.run(trip_intent, taste_profile, corpus)
+    _log_stage("planner", time.perf_counter() - start, agent.prompt_version)
+    return itinerary
+
+
+def _run_summary(itinerary: Itinerary) -> Optional[str]:
+    start = time.perf_counter()
+    agent = SummaryAgent()
+    summary_html = agent.run(itinerary)
+    _log_stage("summary", time.perf_counter() - start, agent.prompt_version)
+    return summary_html
+
+
+def run_trip_pipeline(intent: TripIntent) -> Itinerary:
+    """Execute the orchestrated pipeline for producing an itinerary."""
+
+    pipeline_start = time.perf_counter()
+    _LOGGER.info("Starting trip pipeline for destination: %s", intent.destination or "unknown")
+
+    structured_intent = _run_intake_if_needed(intent)
+    research_corpus = _run_research(structured_intent)
+    taste_profile = _run_taste(structured_intent, research_corpus)
+    itinerary = _run_planner(structured_intent, taste_profile, research_corpus)
+    summary_html = _run_summary(itinerary)
+
+    if summary_html and not itinerary.notes:
+        itinerary.notes = summary_html
+
+    _LOGGER.info("Trip pipeline completed in %.2fs", time.perf_counter() - pipeline_start)
+    return itinerary
+
+
+__all__ = ["run_trip_pipeline", "clear_research_cache"]


### PR DESCRIPTION
## Summary
- add a trip pipeline workflow that coordinates intake, research with caching, taste, planning, and summary stages while logging timing and prompt metadata
- expose the new pipeline helpers through the workflows package
- cover the pipeline with unit tests for itinerary generation, cache behaviour, and logging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccb8bab51483289371c49cadc2c562