### PR TITLE
Add Supabase-backed profile persistence and exports

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from meguru.ui import (
     render_itinerary_tab,
     render_map_tab,
     render_plan_tab,
+    render_profile_tab,
 )
 
 
@@ -54,7 +55,7 @@ def render() -> None:
     render_plan_tab(tab_lookup["Plan"])
     render_itinerary_tab(tab_lookup["Itinerary"])
     render_map_tab(tab_lookup["Map"])
-    tab_lookup["Profile"].write("Traveler profile details will live here.")
+    render_profile_tab(tab_lookup["Profile"])
 
 
 if __name__ == "__main__":

--- a/meguru/core/exporters.py
+++ b/meguru/core/exporters.py
@@ -1,0 +1,202 @@
+"""Utilities for exporting itineraries to common formats."""
+
+from __future__ import annotations
+
+import textwrap
+import uuid
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from typing import Iterable, List, Optional
+
+from meguru.schemas import DayPlan, Itinerary, ItineraryEvent
+
+
+def _format_dt(dt: datetime) -> str:
+    return dt.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _escape_ics_text(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,")
+    escaped = escaped.replace("\n", "\\n")
+    return escaped
+
+
+def itinerary_to_ics(itinerary: Itinerary, *, calendar_name: Optional[str] = None) -> str:
+    """Serialise the itinerary to the iCalendar format."""
+
+    lines: List[str] = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Meguru//Trip Planner//EN",
+    ]
+    if calendar_name:
+        lines.append(f"X-WR-CALNAME:{_escape_ics_text(calendar_name)}")
+    dtstamp = _format_dt(datetime.now(timezone.utc))
+
+    for day_index, day in enumerate(itinerary.days):
+        if not isinstance(day, DayPlan):
+            continue
+        if not day.events:
+            continue
+        base_date = day.date or itinerary.start_date
+        if not base_date:
+            continue
+        for event_index, event in enumerate(day.events):
+            if not isinstance(event, ItineraryEvent):
+                continue
+            uid = uuid.uuid4().hex
+            summary_parts: List[str] = []
+            if event.place and event.place.name:
+                summary_parts.append(event.place.name)
+            if event.title and event.title not in summary_parts:
+                summary_parts.append(event.title)
+            summary = summary_parts[0] if summary_parts else event.title or "Activity"
+            start_dt = datetime.combine(base_date, event.start_time) if event.start_time else None
+            end_dt = datetime.combine(base_date, event.end_time) if event.end_time else None
+            if not start_dt and not end_dt:
+                start_dt = datetime.combine(base_date, datetime.min.time())
+                end_dt = start_dt + timedelta(hours=1)
+            elif start_dt and not end_dt:
+                end_dt = start_dt + timedelta(hours=1)
+            elif end_dt and not start_dt:
+                start_dt = end_dt - timedelta(hours=1)
+
+            lines.append("BEGIN:VEVENT")
+            lines.append(f"UID:{uid}@meguru.ai")
+            lines.append(f"DTSTAMP:{dtstamp}")
+            if start_dt:
+                lines.append(f"DTSTART:{_format_dt(start_dt)}")
+            if end_dt:
+                lines.append(f"DTEND:{_format_dt(end_dt)}")
+            lines.append(f"SUMMARY:{_escape_ics_text(summary)}")
+            if event.description:
+                lines.append(f"DESCRIPTION:{_escape_ics_text(event.description)}")
+            if event.place and event.place.formatted_address:
+                lines.append(f"LOCATION:{_escape_ics_text(event.place.formatted_address)}")
+            lines.append("END:VEVENT")
+
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"
+
+
+def _pdf_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def _wrap_lines(text: str, width: int) -> Iterable[str]:
+    for line in text.splitlines():
+        yield from textwrap.wrap(line, width=width) or [""]
+
+
+def itinerary_to_pdf(itinerary: Itinerary) -> bytes:
+    """Render a very small PDF document summarising the itinerary."""
+
+    buffer = BytesIO()
+    objects: List[bytes] = []
+
+    def add_object(payload: bytes) -> int:
+        objects.append(payload)
+        return len(objects)
+
+    # Page content
+    content_lines: List[str] = []
+    cursor_y = 770
+    line_height = 14
+
+    def write_line(text: str, *, bold: bool = False) -> None:
+        nonlocal cursor_y
+        font = "F2" if bold else "F1"
+        content_lines.append(f"BT /{font} 12 Tf 72 {cursor_y} Td ({_pdf_escape(text)}) Tj ET")
+        cursor_y -= line_height
+
+    title = itinerary.destination or "Trip Itinerary"
+    write_line(title, bold=True)
+    if itinerary.start_date and itinerary.end_date:
+        write_line(
+            f"{itinerary.start_date.strftime('%b %d, %Y')} – {itinerary.end_date.strftime('%b %d, %Y')}",
+            bold=False,
+        )
+    if itinerary.notes:
+        for wrapped in _wrap_lines(itinerary.notes, 90):
+            write_line(wrapped)
+        cursor_y -= line_height // 2
+
+    for day in itinerary.days:
+        label_parts: List[str] = []
+        if day.label:
+            label_parts.append(day.label)
+        if day.date:
+            label_parts.append(day.date.strftime("%A %d %B"))
+        write_line(" ".join(label_parts) or "Day", bold=True)
+        if day.summary:
+            for wrapped in _wrap_lines(day.summary, 90):
+                write_line(f"  {wrapped}")
+        for event in day.events:
+            time_range = []
+            if event.start_time:
+                time_range.append(event.start_time.strftime("%H:%M"))
+            if event.end_time:
+                time_range.append(event.end_time.strftime("%H:%M"))
+            range_text = "-".join(time_range)
+            label_parts = []
+            if event.place and event.place.name:
+                label_parts.append(event.place.name)
+            if event.title and event.title not in label_parts:
+                label_parts.append(event.title)
+            header = "  "
+            if range_text:
+                header += f"[{range_text}] "
+            header += " - ".join(label_parts) if label_parts else event.title or "Activity"
+            write_line(header)
+            if event.description:
+                for wrapped in _wrap_lines(event.description, 84):
+                    write_line(f"    {wrapped}")
+            if event.place and event.place.formatted_address:
+                write_line(f"    {event.place.formatted_address}")
+        cursor_y -= line_height // 2
+
+    content_stream = "\n".join(content_lines).encode("utf-8")
+    contents_obj_index = add_object(
+        f"<< /Length {len(content_stream)} >>\nstream\n".encode("utf-8") + content_stream + b"\nendstream"
+    )
+
+    # Fonts
+    font_regular_index = add_object(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Name /F1 >>")
+    font_bold_index = add_object(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Name /F2 >>")
+
+    # Page
+    page_obj_index = add_object(
+        f"<< /Type /Page /Parent 1 0 R /MediaBox [0 0 612 792] /Contents {contents_obj_index} 0 R /Resources << /Font << /F1 {font_regular_index} 0 R /F2 {font_bold_index} 0 R >> >> >>".encode(
+            "utf-8"
+        )
+    )
+
+    # Pages
+    pages_obj_index = add_object(f"<< /Type /Pages /Count 1 /Kids [{page_obj_index} 0 R] >>".encode("utf-8"))
+
+    # Catalog
+    catalog_index = add_object(f"<< /Type /Catalog /Pages {pages_obj_index} 0 R >>".encode("utf-8"))
+
+    # Serialize PDF
+    buffer.write(b"%PDF-1.4\n")
+    offsets: List[int] = [0]
+    for index, payload in enumerate(objects, start=1):
+        offsets.append(buffer.tell())
+        buffer.write(f"{index} 0 obj\n".encode("utf-8"))
+        buffer.write(payload)
+        buffer.write(b"\nendobj\n")
+    xref_position = buffer.tell()
+    buffer.write(f"xref\n0 {len(objects) + 1}\n".encode("utf-8"))
+    buffer.write(b"0000000000 65535 f \n")
+    cursor = len(objects)
+    for idx in range(cursor):
+        offset = offsets[idx + 1]
+        buffer.write(f"{offset:010d} 00000 n \n".encode("utf-8"))
+    buffer.write(b"trailer\n")
+    buffer.write(f"<< /Size {len(objects) + 1} /Root {catalog_index} 0 R >>\n".encode("utf-8"))
+    buffer.write(f"startxref\n{xref_position}\n%%EOF".encode("utf-8"))
+    return buffer.getvalue()
+
+
+__all__ = ["itinerary_to_ics", "itinerary_to_pdf"]
+

--- a/meguru/core/profile_store.py
+++ b/meguru/core/profile_store.py
@@ -1,0 +1,354 @@
+"""Persistence helpers for storing trips and itineraries."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from meguru.core.supabase_api import SupabaseClient, SupabaseError, SupabaseSession
+from meguru.schemas import Itinerary, ItineraryEvent, Place, TripIntent
+
+
+@dataclass(slots=True)
+class StoredTrip:
+    """Trip persisted in a backing store."""
+
+    id: str
+    user_id: str
+    name: str
+    destination: Optional[str]
+    start_date: Optional[date]
+    end_date: Optional[date]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    intent: TripIntent
+    itinerary: Itinerary
+
+
+def _parse_date(value: Any) -> Optional[date]:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value.split("T")[0])
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            cleaned = value.replace("Z", "+00:00")
+            return datetime.fromisoformat(cleaned)
+        except ValueError:
+            return None
+    return None
+
+
+def _event_slot(event: ItineraryEvent, fallback_index: int) -> Optional[str]:
+    slot_windows = (
+        ("Morning", time(6, 0), time(11, 0)),
+        ("Lunch", time(11, 0), time(14, 0)),
+        ("Afternoon", time(14, 0), time(17, 0)),
+        ("Dinner", time(17, 0), time(20, 30)),
+        ("Evening", time(20, 30), time(23, 59, 59)),
+    )
+    slot_keywords = {
+        "breakfast": "Morning",
+        "brunch": "Morning",
+        "coffee": "Morning",
+        "sunrise": "Morning",
+        "lunch": "Lunch",
+        "midday": "Lunch",
+        "afternoon": "Afternoon",
+        "tea": "Afternoon",
+        "museum": "Afternoon",
+        "dinner": "Dinner",
+        "supper": "Dinner",
+        "tasting": "Dinner",
+        "evening": "Evening",
+        "night": "Evening",
+        "drinks": "Evening",
+        "bar": "Evening",
+        "show": "Evening",
+    }
+
+    if event.start_time:
+        for name, start, end in slot_windows:
+            if start <= event.start_time <= end:
+                return name
+
+    haystack_parts = [
+        event.title or "",
+        event.description or "",
+        " ".join(event.tags or []),
+    ]
+    if event.place and event.place.name:
+        haystack_parts.append(event.place.name)
+    haystack = " ".join(part.lower() for part in haystack_parts if part)
+    for keyword, slot_name in slot_keywords.items():
+        if keyword in haystack:
+            return slot_name
+    slots = ["Morning", "Lunch", "Afternoon", "Dinner", "Evening"]
+    return slots[fallback_index % len(slots)] if slots else None
+
+
+class InMemoryProfileStore:
+    """Fallback store used when Supabase is not configured."""
+
+    def __init__(self, user_id: str) -> None:
+        self._user_id = user_id
+        self._records: MutableMapping[str, StoredTrip] = {}
+
+    def _next_id(self) -> str:
+        return str(uuid.uuid4())
+
+    def save_trip(self, intent: TripIntent, itinerary: Itinerary, *, name: Optional[str] = None) -> StoredTrip:
+        trip_id = self._next_id()
+        now = datetime.now(timezone.utc)
+        record = StoredTrip(
+            id=trip_id,
+            user_id=self._user_id,
+            name=name or itinerary.destination or intent.destination or "Trip",
+            destination=itinerary.destination,
+            start_date=itinerary.start_date,
+            end_date=itinerary.end_date,
+            created_at=now,
+            updated_at=now,
+            intent=intent,
+            itinerary=itinerary,
+        )
+        self._records[trip_id] = record
+        return record
+
+    def list_trips(self) -> List[StoredTrip]:
+        return sorted(
+            self._records.values(),
+            key=lambda trip: trip.created_at or datetime.now(timezone.utc),
+            reverse=True,
+        )
+
+    def get_trip(self, trip_id: str) -> Optional[StoredTrip]:
+        return self._records.get(trip_id)
+
+    def duplicate_trip(self, trip_id: str) -> Optional[StoredTrip]:
+        original = self._records.get(trip_id)
+        if not original:
+            return None
+        copy = StoredTrip(
+            id=self._next_id(),
+            user_id=self._user_id,
+            name=f"{original.name} (Copy)",
+            destination=original.destination,
+            start_date=original.start_date,
+            end_date=original.end_date,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            intent=original.intent.model_copy(deep=True),
+            itinerary=original.itinerary.model_copy(deep=True),
+        )
+        self._records[copy.id] = copy
+        return copy
+
+
+class SupabaseProfileStore:
+    """Supabase-backed implementation of trip persistence."""
+
+    def __init__(self, client: SupabaseClient, session: SupabaseSession) -> None:
+        self._client = client
+        self._session = session
+
+    @property
+    def user_id(self) -> str:
+        return self._session.user.id
+
+    def _ensure_user(self) -> None:
+        user = self._session.user
+        payload = {
+            "id": user.id,
+            "email": user.email,
+            "full_name": user.raw.get("user_metadata", {}).get("full_name") if isinstance(user.raw, Mapping) else None,
+            "avatar_url": user.raw.get("user_metadata", {}).get("avatar_url") if isinstance(user.raw, Mapping) else None,
+        }
+        self._client.insert(
+            "users",
+            [payload],
+            access_token=self._session.access_token,
+            returning=False,
+            prefer_resolution="merge-duplicates",
+            on_conflict="id",
+        )
+
+    def _build_place_rows(self, itinerary_id: str, itinerary: Itinerary) -> List[Mapping[str, Any]]:
+        seen: Dict[str, Place] = {}
+        rows: List[Mapping[str, Any]] = []
+        for day in itinerary.days:
+            for event in day.events:
+                if not event.place:
+                    continue
+                place = event.place
+                place_key = place.place_id or f"{place.name}-{place.formatted_address}" if place.name else None
+                if not place_key:
+                    continue
+                if place_key in seen:
+                    continue
+                seen[place_key] = place
+                rows.append(
+                    {
+                        "itinerary_id": itinerary_id,
+                        "place_id": place.place_id,
+                        "name": place.name,
+                        "data": place.model_dump(mode="json"),
+                    }
+                )
+        return rows
+
+    def _build_event_rows(self, itinerary_id: str, itinerary: Itinerary) -> List[Mapping[str, Any]]:
+        rows: List[Mapping[str, Any]] = []
+        for day_index, day in enumerate(itinerary.days):
+            event_date = day.date
+            for event_index, event in enumerate(day.events):
+                start_dt = None
+                end_dt = None
+                if event_date and event.start_time:
+                    start_dt = datetime.combine(event_date, event.start_time)
+                if event_date and event.end_time:
+                    end_dt = datetime.combine(event_date, event.end_time)
+                slot = _event_slot(event, event_index)
+                rows.append(
+                    {
+                        "itinerary_id": itinerary_id,
+                        "day_index": day_index,
+                        "event_index": event_index,
+                        "starts_at": start_dt.isoformat() if start_dt else None,
+                        "ends_at": end_dt.isoformat() if end_dt else None,
+                        "slot": slot,
+                        "data": event.model_dump(mode="json"),
+                    }
+                )
+        return rows
+
+    def _compose_trip(self, trip_row: Mapping[str, Any], itinerary_row: Optional[Mapping[str, Any]]) -> StoredTrip:
+        intent_payload = trip_row.get("trip_intent") or {}
+        intent = TripIntent.model_validate(intent_payload)
+        itinerary_payload: Dict[str, Any] = {}
+        if itinerary_row:
+            itinerary_payload = itinerary_row.get("itinerary") or {}
+            if itinerary_row.get("notes") and "notes" not in itinerary_payload:
+                itinerary_payload["notes"] = itinerary_row.get("notes")
+        itinerary = Itinerary.model_validate(itinerary_payload) if itinerary_payload else Itinerary(
+            destination=intent.destination or trip_row.get("destination") or intent.notes or "Trip"
+        )
+        start_date = _parse_date(trip_row.get("start_date"))
+        end_date = _parse_date(trip_row.get("end_date"))
+        created_at = _parse_datetime(trip_row.get("created_at"))
+        updated_at = _parse_datetime(trip_row.get("updated_at"))
+        return StoredTrip(
+            id=str(trip_row.get("id")),
+            user_id=str(trip_row.get("user_id")),
+            name=str(trip_row.get("name") or itinerary.destination or intent.destination or "Trip"),
+            destination=trip_row.get("destination") or itinerary.destination,
+            start_date=start_date or itinerary.start_date,
+            end_date=end_date or itinerary.end_date,
+            created_at=created_at,
+            updated_at=updated_at,
+            intent=intent,
+            itinerary=itinerary,
+        )
+
+    def _fetch_trip_rows(self, *, trip_id: Optional[str] = None) -> List[StoredTrip]:
+        filters: Dict[str, Any] = {"user_id": f"eq.{self.user_id}"}
+        if trip_id:
+            filters["id"] = f"eq.{trip_id}"
+        rows = self._client.select(
+            "trips",
+            access_token=self._session.access_token,
+            filters=filters,
+            select="*,itineraries(*)",
+            order="updated_at.desc",
+        )
+        records: List[StoredTrip] = []
+        for row in rows:
+            itineraries = row.get("itineraries") or []
+            itinerary_row = itineraries[0] if itineraries else None
+            try:
+                records.append(self._compose_trip(row, itinerary_row))
+            except Exception as exc:  # noqa: BLE001 - surface data errors to callers
+                raise SupabaseError(f"Failed to parse trip payload: {exc}") from exc
+        return records
+
+    def list_trips(self) -> List[StoredTrip]:
+        return self._fetch_trip_rows()
+
+    def get_trip(self, trip_id: str) -> Optional[StoredTrip]:
+        rows = self._fetch_trip_rows(trip_id=trip_id)
+        return rows[0] if rows else None
+
+    def save_trip(self, intent: TripIntent, itinerary: Itinerary, *, name: Optional[str] = None) -> StoredTrip:
+        self._ensure_user()
+        trip_name = name or itinerary.destination or intent.destination or "Trip"
+        trip_payload = {
+            "user_id": self.user_id,
+            "name": trip_name,
+            "destination": itinerary.destination,
+            "start_date": itinerary.start_date.isoformat() if itinerary.start_date else None,
+            "end_date": itinerary.end_date.isoformat() if itinerary.end_date else None,
+            "trip_intent": intent.model_dump(mode="json"),
+        }
+        trip_rows = self._client.insert("trips", [trip_payload], access_token=self._session.access_token)
+        if not trip_rows:
+            raise SupabaseError("Supabase did not return trip row on insert")
+        trip_row = trip_rows[0]
+        trip_id = str(trip_row.get("id"))
+        itinerary_payload = {
+            "trip_id": trip_id,
+            "itinerary": itinerary.model_dump(mode="json"),
+            "notes": itinerary.notes,
+        }
+        itinerary_rows = self._client.insert("itineraries", [itinerary_payload], access_token=self._session.access_token)
+        itinerary_row = itinerary_rows[0] if itinerary_rows else None
+        itinerary_id = str(itinerary_row.get("id")) if itinerary_row else None
+        if itinerary_id:
+            place_rows = self._build_place_rows(itinerary_id, itinerary)
+            if place_rows:
+                self._client.insert(
+                    "places",
+                    place_rows,
+                    access_token=self._session.access_token,
+                    returning=False,
+                )
+            event_rows = self._build_event_rows(itinerary_id, itinerary)
+            if event_rows:
+                self._client.insert(
+                    "events",
+                    event_rows,
+                    access_token=self._session.access_token,
+                    returning=False,
+                )
+        stored = self.get_trip(trip_id)
+        if not stored:
+            raise SupabaseError("Unable to fetch stored trip after insert")
+        return stored
+
+    def duplicate_trip(self, trip_id: str) -> Optional[StoredTrip]:
+        original = self.get_trip(trip_id)
+        if not original:
+            return None
+        return self.save_trip(
+            original.intent.model_copy(deep=True),
+            original.itinerary.model_copy(deep=True),
+            name=f"{original.name} (Copy)",
+        )
+
+
+__all__ = [
+    "InMemoryProfileStore",
+    "StoredTrip",
+    "SupabaseProfileStore",
+]
+

--- a/meguru/core/supabase_api.py
+++ b/meguru/core/supabase_api.py
@@ -1,0 +1,251 @@
+"""Minimal Supabase REST API client used by the Meguru application."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+import requests
+
+
+class SupabaseError(RuntimeError):
+    """Raised when a Supabase API request fails."""
+
+
+@dataclass(slots=True)
+class SupabaseUser:
+    """Supabase authenticated user representation."""
+
+    id: str
+    email: Optional[str]
+    raw: Mapping[str, Any]
+
+
+@dataclass(slots=True)
+class SupabaseSession:
+    """Authentication session details returned by Supabase."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str
+    expires_at: Optional[int]
+    user: SupabaseUser
+
+    def is_expired(self, *, safety_seconds: int = 60) -> bool:
+        """Return ``True`` if the token has expired or is close to expiring."""
+
+        if not self.expires_at:
+            return False
+        return time.time() >= (self.expires_at - safety_seconds)
+
+
+class SupabaseClient:
+    """Very small wrapper around Supabase's REST and auth HTTP APIs."""
+
+    def __init__(self, url: str, anon_key: str, *, http_session: Optional[requests.Session] = None) -> None:
+        self._url = url.rstrip("/")
+        self._anon_key = anon_key
+        self._session = http_session or requests.Session()
+        self._session.headers.setdefault("apikey", anon_key)
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @property
+    def anon_key(self) -> str:
+        return self._anon_key
+
+    @classmethod
+    def from_env(cls) -> "SupabaseClient | None":
+        """Return a client instance using ``SUPABASE_URL`` and ``SUPABASE_ANON_KEY``."""
+
+        url = os.getenv("SUPABASE_URL")
+        anon_key = os.getenv("SUPABASE_ANON_KEY")
+        if not url or not anon_key:
+            return None
+        return cls(url, anon_key)
+
+    def _auth_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        endpoint = f"{self._url}/auth/v1{path}"
+        response = self._session.request(
+            method,
+            endpoint,
+            json=payload,
+            headers={"Content-Type": "application/json", "apikey": self._anon_key},
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise SupabaseError(f"Supabase auth request failed ({response.status_code}): {response.text}")
+        data: Dict[str, Any] = response.json()
+        return data
+
+    def _rest_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        access_token: str,
+        params: Optional[Mapping[str, Any]] = None,
+        payload: Optional[Any] = None,
+        extra_headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        endpoint = f"{self._url}/rest/v1/{path.lstrip('/')}"
+        headers: MutableMapping[str, str] = {
+            "Authorization": f"Bearer {access_token}",
+            "apikey": self._anon_key,
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+        if method.upper() in {"POST", "PATCH", "PUT"}:
+            headers.setdefault("Content-Type", "application/json")
+        response = self._session.request(
+            method,
+            endpoint,
+            params=params,
+            json=payload,
+            headers=headers,
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise SupabaseError(
+                f"Supabase REST request failed ({response.status_code}) for {path}: {response.text}"
+            )
+        if response.text:
+            try:
+                return response.json()
+            except ValueError:
+                return response.text
+        return None
+
+    @staticmethod
+    def _parse_session(payload: Mapping[str, Any]) -> SupabaseSession:
+        user_data = payload.get("user") or {}
+        access_token = payload.get("access_token")
+        refresh_token = payload.get("refresh_token")
+        token_type = payload.get("token_type", "bearer")
+        expires_at = payload.get("expires_at")
+        if not access_token or not refresh_token:
+            raise SupabaseError("Supabase auth response missing access or refresh token")
+        user_id = user_data.get("id")
+        if not user_id:
+            raise SupabaseError("Supabase auth response missing user id")
+        user_email = user_data.get("email")
+        user = SupabaseUser(id=user_id, email=user_email, raw=dict(user_data))
+        return SupabaseSession(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            token_type=token_type,
+            expires_at=expires_at,
+            user=user,
+        )
+
+    def sign_in_with_password(self, email: str, password: str) -> SupabaseSession:
+        payload = {"email": email, "password": password}
+        data = self._auth_request("POST", "/token?grant_type=password", payload=payload)
+        return self._parse_session(data)
+
+    def sign_up_with_password(self, email: str, password: str) -> SupabaseSession:
+        payload = {"email": email, "password": password}
+        data = self._auth_request("POST", "/signup", payload=payload)
+        return self._parse_session(data)
+
+    def refresh_session(self, refresh_token: str) -> SupabaseSession:
+        payload = {"refresh_token": refresh_token}
+        data = self._auth_request("POST", "/token?grant_type=refresh_token", payload=payload)
+        return self._parse_session(data)
+
+    def select(
+        self,
+        table: str,
+        *,
+        access_token: str,
+        filters: Optional[Mapping[str, Any]] = None,
+        select: Optional[str] = None,
+        order: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if filters:
+            params.update(filters)
+        if select:
+            params["select"] = select
+        if order:
+            params["order"] = order
+        if limit is not None:
+            params["limit"] = limit
+        result = self._rest_request("GET", table, access_token=access_token, params=params)
+        if isinstance(result, list):
+            return result
+        return []
+
+    def insert(
+        self,
+        table: str,
+        rows: Iterable[Mapping[str, Any]],
+        *,
+        access_token: str,
+        returning: bool = True,
+        prefer_resolution: Optional[str] = None,
+        on_conflict: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        payload = list(rows)
+        if not payload:
+            return []
+        params: Dict[str, Any] = {}
+        if on_conflict:
+            params["on_conflict"] = on_conflict
+        prefer_parts = []
+        if returning:
+            prefer_parts.append("return=representation")
+        if prefer_resolution:
+            prefer_parts.append(f"resolution={prefer_resolution}")
+        headers: Dict[str, str] = {}
+        if prefer_parts:
+            headers["Prefer"] = ",".join(prefer_parts)
+        result = self._rest_request(
+            "POST",
+            table,
+            access_token=access_token,
+            params=params,
+            payload=payload,
+            extra_headers=headers,
+        )
+        if isinstance(result, list):
+            return result
+        return []
+
+    def update(
+        self,
+        table: str,
+        *,
+        access_token: str,
+        filters: Mapping[str, Any],
+        values: Mapping[str, Any],
+        returning: bool = False,
+    ) -> List[Dict[str, Any]]:
+        prefer = "return=representation" if returning else None
+        headers = {"Prefer": prefer} if prefer else None
+        result = self._rest_request(
+            "PATCH",
+            table,
+            access_token=access_token,
+            params=dict(filters),
+            payload=dict(values),
+            extra_headers=headers,
+        )
+        if isinstance(result, list):
+            return result
+        return []
+
+
+__all__ = ["SupabaseClient", "SupabaseSession", "SupabaseUser", "SupabaseError"]
+

--- a/meguru/ui/__init__.py
+++ b/meguru/ui/__init__.py
@@ -3,6 +3,14 @@
 from .itinerary import SELECTED_SLOT_KEY, render_itinerary_tab
 from .map import render_map_tab
 from .plan import ensure_plan_state, render_plan_tab
+from .profile import (
+    PROFILE_LOCAL_STORE_KEY,
+    PROFILE_STATUS_KEY,
+    SUPABASE_SESSION_KEY,
+    SUPABASE_TOKENS_KEY,
+    render_profile_tab,
+    save_trip_to_profile,
+)
 
 __all__ = [
     "ensure_plan_state",
@@ -10,4 +18,10 @@ __all__ = [
     "render_itinerary_tab",
     "SELECTED_SLOT_KEY",
     "render_plan_tab",
+    "render_profile_tab",
+    "save_trip_to_profile",
+    "PROFILE_LOCAL_STORE_KEY",
+    "PROFILE_STATUS_KEY",
+    "SUPABASE_SESSION_KEY",
+    "SUPABASE_TOKENS_KEY",
 ]

--- a/meguru/ui/profile.py
+++ b/meguru/ui/profile.py
@@ -1,0 +1,267 @@
+"""Profile tab UI with Supabase persistence and exports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import streamlit as st
+
+from meguru.core.db import connection_ctx, ensure_application_tables
+from meguru.core.exporters import itinerary_to_ics, itinerary_to_pdf
+from meguru.core.profile_store import (
+    InMemoryProfileStore,
+    StoredTrip,
+    SupabaseProfileStore,
+)
+from meguru.core.supabase_api import SupabaseClient, SupabaseError, SupabaseSession
+from meguru.schemas import Itinerary, TripIntent
+
+
+SUPABASE_SESSION_KEY = "_supabase_session"
+SUPABASE_TOKENS_KEY = "_supabase_tokens"
+PROFILE_LOCAL_STORE_KEY = "_profile_local_store"
+PROFILE_STATUS_KEY = "_profile_status"
+PROFILE_SCHEMA_READY_KEY = "_profile_schema_ready"
+
+
+@dataclass(slots=True)
+class StoreContext:
+    store: InMemoryProfileStore | SupabaseProfileStore
+    client: Optional[SupabaseClient]
+    session: Optional[SupabaseSession]
+    using_supabase: bool
+
+
+def _get_local_store() -> InMemoryProfileStore:
+    store = st.session_state.get(PROFILE_LOCAL_STORE_KEY)
+    if not isinstance(store, InMemoryProfileStore):
+        store = InMemoryProfileStore(user_id="local-user")
+        st.session_state[PROFILE_LOCAL_STORE_KEY] = store
+    return store
+
+
+def _resolve_store() -> StoreContext:
+    client = SupabaseClient.from_env()
+    local_store = _get_local_store()
+    if not client:
+        return StoreContext(local_store, None, None, False)
+
+    session = st.session_state.get(SUPABASE_SESSION_KEY)
+    if isinstance(session, SupabaseSession) and not session.is_expired():
+        return StoreContext(SupabaseProfileStore(client, session), client, session, True)
+
+    tokens = st.session_state.get(SUPABASE_TOKENS_KEY)
+    if tokens and isinstance(tokens, dict):
+        refresh_token = tokens.get("refresh_token")
+        if refresh_token:
+            try:
+                refreshed = client.refresh_session(refresh_token)
+            except SupabaseError as exc:
+                st.warning(f"Supabase session refresh failed: {exc}")
+                st.session_state.pop(SUPABASE_TOKENS_KEY, None)
+                st.session_state.pop(SUPABASE_SESSION_KEY, None)
+            else:
+                st.session_state[SUPABASE_SESSION_KEY] = refreshed
+                st.session_state[SUPABASE_TOKENS_KEY] = {
+                    "access_token": refreshed.access_token,
+                    "refresh_token": refreshed.refresh_token,
+                    "expires_at": refreshed.expires_at,
+                }
+                return StoreContext(SupabaseProfileStore(client, refreshed), client, refreshed, True)
+
+    return StoreContext(local_store, client, None, False)
+
+
+def _ensure_schema() -> None:
+    if st.session_state.get(PROFILE_SCHEMA_READY_KEY):
+        return
+    try:
+        with connection_ctx() as connection:
+            ensure_application_tables(connection)
+    except Exception as exc:  # noqa: BLE001 - surfaced to user
+        st.warning(f"Unable to validate Supabase tables: {exc}")
+        st.session_state[PROFILE_SCHEMA_READY_KEY] = False
+    else:
+        st.session_state[PROFILE_SCHEMA_READY_KEY] = True
+
+
+def _render_auth_controls(client: SupabaseClient) -> None:
+    st.markdown("#### Supabase account")
+    with st.form("profile_auth_form", clear_on_submit=False):
+        email = st.text_input("Email", key="profile_auth_email")
+        password = st.text_input("Password", type="password", key="profile_auth_password")
+        submit_col, register_col = st.columns(2)
+        sign_in_clicked = submit_col.form_submit_button("Sign in", use_container_width=True)
+        register_clicked = register_col.form_submit_button("Register", use_container_width=True)
+        if sign_in_clicked or register_clicked:
+            if not email or not password:
+                st.warning("Enter both email and password.")
+            else:
+                try:
+                    if register_clicked:
+                        session = client.sign_up_with_password(email, password)
+                    else:
+                        session = client.sign_in_with_password(email, password)
+                except SupabaseError as exc:
+                    st.error(f"Authentication failed: {exc}")
+                else:
+                    st.session_state[SUPABASE_SESSION_KEY] = session
+                    st.session_state[SUPABASE_TOKENS_KEY] = {
+                        "access_token": session.access_token,
+                        "refresh_token": session.refresh_token,
+                        "expires_at": session.expires_at,
+                    }
+                    st.session_state[PROFILE_STATUS_KEY] = "Signed in successfully."
+                    st.experimental_rerun()
+
+
+def _render_user_summary(session: SupabaseSession) -> None:
+    user = session.user
+    st.write(
+        f"Signed in as **{user.email or user.id}**",  # noqa: E501 - Markdown formatting for clarity
+    )
+    sign_out = st.button("Sign out", key="profile_sign_out")
+    if sign_out:
+        st.session_state.pop(SUPABASE_SESSION_KEY, None)
+        st.session_state.pop(SUPABASE_TOKENS_KEY, None)
+        st.session_state[PROFILE_STATUS_KEY] = "Signed out."
+        st.experimental_rerun()
+
+
+def _load_trips(store: InMemoryProfileStore | SupabaseProfileStore) -> List[StoredTrip]:
+    try:
+        return store.list_trips()
+    except SupabaseError as exc:
+        st.error(f"Unable to load trips: {exc}")
+        return []
+
+
+def _render_trip_summary(trip: StoredTrip, store: InMemoryProfileStore | SupabaseProfileStore) -> None:
+    with st.expander(trip.name, expanded=False):
+        if trip.start_date and trip.end_date:
+            st.caption(
+                f"{trip.start_date.strftime('%b %d, %Y')} – {trip.end_date.strftime('%b %d, %Y')}"
+            )
+        if trip.intent.interests:
+            st.caption("Interests: " + ", ".join(trip.intent.interests))
+
+        action_cols = st.columns(3)
+        duplicate_clicked = action_cols[0].button(
+            "Duplicate",
+            key=f"profile_duplicate_{trip.id}",
+            use_container_width=True,
+        )
+        ics_data = itinerary_to_ics(trip.itinerary, calendar_name=trip.name)
+        action_cols[1].download_button(
+            "Download ICS",
+            data=ics_data,
+            file_name=f"{trip.name}.ics",
+            mime="text/calendar",
+            key=f"profile_download_ics_{trip.id}",
+            use_container_width=True,
+        )
+        pdf_data = itinerary_to_pdf(trip.itinerary)
+        action_cols[2].download_button(
+            "Download PDF",
+            data=pdf_data,
+            file_name=f"{trip.name}.pdf",
+            mime="application/pdf",
+            key=f"profile_download_pdf_{trip.id}",
+            use_container_width=True,
+        )
+
+        if duplicate_clicked:
+            try:
+                duplicate = store.duplicate_trip(trip.id)
+            except SupabaseError as exc:
+                st.error(f"Unable to duplicate trip: {exc}")
+            except Exception as exc:  # noqa: BLE001 - surface unexpected issues
+                st.error(f"Unexpected error duplicating trip: {exc}")
+            else:
+                if duplicate:
+                    st.session_state[PROFILE_STATUS_KEY] = f"Duplicated {trip.name}."
+                    st.experimental_rerun()
+
+        st.markdown("### Day by day")
+        for day in trip.itinerary.days:
+            day_label = day.label or day.date.strftime("%A") if day.date else "Day"
+            st.markdown(f"**{day_label}**")
+            for event in day.events:
+                event_title = event.title or (event.place.name if event.place else "Activity")
+                detail_parts: List[str] = []
+                if event.start_time:
+                    detail_parts.append(event.start_time.strftime("%H:%M"))
+                if event.end_time:
+                    detail_parts.append(event.end_time.strftime("%H:%M"))
+                timing = "–".join(detail_parts)
+                header = event_title
+                if timing:
+                    header += f" ({timing})"
+                st.write(f"- {header}")
+                if event.description:
+                    st.caption(event.description)
+
+
+def save_trip_to_profile(
+    intent: TripIntent,
+    itinerary: Itinerary,
+    *,
+    name: Optional[str] = None,
+) -> Tuple[Optional[StoredTrip], Optional[str]]:
+    """Persist the supplied trip using the active profile store."""
+
+    context = _resolve_store()
+    store = context.store
+    if context.using_supabase:
+        _ensure_schema()
+    try:
+        saved = store.save_trip(intent, itinerary, name=name)
+    except SupabaseError as exc:
+        return None, str(exc)
+    except Exception as exc:  # noqa: BLE001 - unexpected runtime failure
+        return None, str(exc)
+    st.session_state[PROFILE_STATUS_KEY] = f"Saved {saved.name}."
+    return saved, None
+
+
+def render_profile_tab(container) -> None:
+    """Render the profile tab with authentication and trip management."""
+
+    context = _resolve_store()
+    with container:
+        st.subheader("Profile")
+
+        status = st.session_state.pop(PROFILE_STATUS_KEY, None)
+        if status:
+            st.success(status)
+
+        if context.client is None:
+            st.info(
+                "Configure `SUPABASE_URL` and `SUPABASE_ANON_KEY` to sync trips to Supabase. "
+                "Trips are stored locally for this session."
+            )
+        elif context.session is None:
+            _render_auth_controls(context.client)
+        else:
+            _ensure_schema()
+            _render_user_summary(context.session)
+
+        trips = _load_trips(context.store)
+        if not trips:
+            st.info("No trips saved yet. Generate an itinerary and save it to see it here.")
+            return
+
+        for trip in trips:
+            _render_trip_summary(trip, context.store)
+
+
+__all__ = [
+    "PROFILE_LOCAL_STORE_KEY",
+    "PROFILE_STATUS_KEY",
+    "SUPABASE_SESSION_KEY",
+    "SUPABASE_TOKENS_KEY",
+    "render_profile_tab",
+    "save_trip_to_profile",
+]
+

--- a/tests/test_profile_and_exports.py
+++ b/tests/test_profile_and_exports.py
@@ -1,0 +1,57 @@
+from datetime import date, time
+
+from meguru.core.exporters import itinerary_to_ics, itinerary_to_pdf
+from meguru.core.profile_store import InMemoryProfileStore
+from meguru.schemas import DayPlan, Itinerary, ItineraryEvent, Place, TripIntent
+
+
+def _sample_trip() -> tuple[TripIntent, Itinerary]:
+    intent = TripIntent(destination="Kyoto", interests=["Food"])
+    itinerary = Itinerary(
+        destination="Kyoto",
+        start_date=date(2024, 5, 1),
+        end_date=date(2024, 5, 3),
+        days=[
+            DayPlan(
+                label="Day 1",
+                events=[
+                    ItineraryEvent(
+                        title="Visit Fushimi Inari",
+                        description="Walk through the torii gates.",
+                        start_time=time(9, 0),
+                        end_time=time(11, 0),
+                        place=Place(
+                            place_id="place_123",
+                            name="Fushimi Inari Shrine",
+                            formatted_address="68 Fukakusa Yabunouchicho, Kyoto",
+                        ),
+                    )
+                ],
+            )
+        ],
+    )
+    return intent, itinerary
+
+
+def test_itinerary_to_ics_contains_events():
+    _, itinerary = _sample_trip()
+    ics_data = itinerary_to_ics(itinerary, calendar_name="Kyoto Adventure")
+    assert "BEGIN:VEVENT" in ics_data
+    assert "Fushimi Inari Shrine" in ics_data
+
+
+def test_itinerary_to_pdf_starts_with_pdf_header():
+    _, itinerary = _sample_trip()
+    pdf_bytes = itinerary_to_pdf(itinerary)
+    assert pdf_bytes.startswith(b"%PDF-1.4")
+
+
+def test_in_memory_store_save_and_duplicate():
+    intent, itinerary = _sample_trip()
+    store = InMemoryProfileStore(user_id="user-1")
+    saved = store.save_trip(intent, itinerary)
+    assert saved.id in {trip.id for trip in store.list_trips()}
+    duplicate = store.duplicate_trip(saved.id)
+    assert duplicate is not None
+    trip_ids = {trip.id for trip in store.list_trips()}
+    assert saved.id in trip_ids and duplicate.id in trip_ids


### PR DESCRIPTION
## Summary
- add a lightweight Supabase REST client and ensure database tables for users, trips, itineraries, places, and events are created
- implement persistence helpers and a Profile tab UI that supports Supabase auth, trip listing, duplication, and export
- enable saving itineraries from the Itinerary tab and generate ICS/PDF exports with accompanying unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccef4e04608328aedc75f59a109288