### PR TITLE
Add evaluation checks and CI reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master", "develop", "dev"]
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install poetry
+          poetry install
+
+      - name: Run tests
+        id: pytest
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          poetry run pytest | tee pytest-output.txt
+          exit_code=${PIPESTATUS[0]}
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on pull request
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('pytest-output.txt', 'utf8');
+            const exitCode = '${{ steps.pytest.outputs.exit_code }}';
+            const status = exitCode === '0' ? '✅ Tests passed' : '❌ Tests failed';
+            const body = `${status}\n\n\`\`\`\n${output.substring(0, 65000)}\n\`\`\``;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+
+      - name: Fail if tests failed
+        if: steps.pytest.outputs.exit_code != '0'
+        run: exit 1

--- a/meguru/core/__init__.py
+++ b/meguru/core/__init__.py
@@ -1,0 +1,15 @@
+"""Core utilities for Meguru."""
+
+from .evaluations import (
+    category_diversity_score,
+    daily_transfer_distance_km,
+    has_meal_coverage,
+    opening_hours_conflicts,
+)
+
+__all__ = [
+    "category_diversity_score",
+    "daily_transfer_distance_km",
+    "has_meal_coverage",
+    "opening_hours_conflicts",
+]

--- a/meguru/core/evaluations.py
+++ b/meguru/core/evaluations.py
@@ -1,0 +1,134 @@
+"""Lightweight quality checks for generated itineraries."""
+
+from __future__ import annotations
+
+from datetime import time
+from math import asin, cos, radians, sin, sqrt
+from typing import Mapping, MutableMapping, Sequence
+
+from meguru.schemas import Itinerary, ItineraryEvent
+
+
+_MEAL_TAGS = {"meal", "breakfast", "lunch", "dinner", "brunch", "supper"}
+
+
+def _event_coordinates(event: ItineraryEvent) -> tuple[float, float] | None:
+    place = event.place
+    if (
+        place is None
+        or place.latitude is None
+        or place.longitude is None
+    ):
+        return None
+    return (place.latitude, place.longitude)
+
+
+def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Return the spherical distance in kilometres between two coordinates."""
+
+    radius_km = 6371.0
+
+    d_lat = radians(lat2 - lat1)
+    d_lon = radians(lon2 - lon1)
+    a = sin(d_lat / 2) ** 2 + cos(radians(lat1)) * cos(radians(lat2)) * sin(d_lon / 2) ** 2
+    c = 2 * asin(sqrt(a))
+    return radius_km * c
+
+
+def daily_transfer_distance_km(itinerary: Itinerary) -> Mapping[str, float]:
+    """Calculate per-day transfer distances using event coordinates."""
+
+    totals: MutableMapping[str, float] = {}
+    for index, day in enumerate(itinerary.days):
+        prev_coords: tuple[float, float] | None = None
+        total_distance = 0.0
+        for event in day.events:
+            coords = _event_coordinates(event)
+            if prev_coords and coords:
+                total_distance += _haversine_km(*prev_coords, *coords)
+            if coords:
+                prev_coords = coords
+        label = day.label or f"Day {index + 1}"
+        totals[label] = total_distance
+    return totals
+
+
+def _has_valid_times(event: ItineraryEvent) -> bool:
+    return event.start_time is not None and event.end_time is not None
+
+
+def _times_overlap(a_start: time, a_end: time, b_start: time, b_end: time) -> bool:
+    return max(a_start, b_start) < min(a_end, b_end)
+
+
+def opening_hours_conflicts(itinerary: Itinerary) -> int:
+    """Return the count of events whose times conflict within each day."""
+
+    conflicts = 0
+    for day in itinerary.days:
+        timed_events = [event for event in day.events if _has_valid_times(event)]
+        timed_events.sort(key=lambda event: event.start_time)
+        for event in timed_events:
+            if event.start_time and event.end_time and event.end_time <= event.start_time:
+                conflicts += 1
+        for first, second in zip(timed_events, timed_events[1:]):
+            if (
+                first.start_time
+                and first.end_time
+                and second.start_time
+                and second.end_time
+                and _times_overlap(first.start_time, first.end_time, second.start_time, second.end_time)
+            ):
+                conflicts += 1
+    return conflicts
+
+
+def category_diversity_score(itinerary: Itinerary) -> int:
+    """Return the count of distinct activity categories across the itinerary."""
+
+    categories: set[str] = set()
+    for event in itinerary.all_events():
+        categories.update(
+            tag.lower()
+            for tag in event.tags
+            if tag and tag.lower() not in _MEAL_TAGS
+        )
+        place = event.place
+        if place and place.types:
+            categories.update(t.lower() for t in place.types if t)
+    return len(categories)
+
+
+def has_meal_coverage(itinerary: Itinerary, *, required_tags: Sequence[str] | None = None) -> bool:
+    """Return True when each day contains at least one meal-tagged event."""
+
+    if not itinerary.days:
+        return False
+
+    required = {tag.lower() for tag in required_tags} if required_tags else _MEAL_TAGS
+
+    for day in itinerary.days:
+        if not day.events:
+            return False
+
+        meal_found = False
+        for event in day.events:
+            tags = {tag.lower() for tag in event.tags}
+            title = event.title.lower()
+            if tags & required:
+                meal_found = True
+                break
+            if any(token in title for token in required):
+                meal_found = True
+                break
+        if not meal_found:
+            return False
+    return True
+
+
+__all__ = [
+    "daily_transfer_distance_km",
+    "opening_hours_conflicts",
+    "category_diversity_score",
+    "has_meal_coverage",
+]

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import date, time
+
+from meguru.core.evaluations import (
+    category_diversity_score,
+    daily_transfer_distance_km,
+    has_meal_coverage,
+    opening_hours_conflicts,
+)
+from meguru.schemas import DayPlan, Itinerary, ItineraryEvent, Place
+
+
+def _place(place_id: str, name: str, latitude: float, longitude: float, *, types: list[str]) -> Place:
+    return Place(
+        place_id=place_id,
+        name=name,
+        latitude=latitude,
+        longitude=longitude,
+        types=types,
+    )
+
+
+def _build_sample_itinerary() -> Itinerary:
+    morning_cafe = _place(
+        "cafe-kyoto",
+        "Morning Cafe",
+        35.0116,
+        135.7681,
+        types=["restaurant", "cafe", "food"],
+    )
+    bamboo_grove = _place(
+        "bamboo-grove",
+        "Bamboo Grove Walk",
+        35.0150,
+        135.7697,
+        types=["tourist_attraction", "park"],
+    )
+    tea_house = _place(
+        "tea-house",
+        "Tea Ceremony House",
+        35.0120,
+        135.7650,
+        types=["point_of_interest", "museum"],
+    )
+    downtown_izakaya = _place(
+        "izakaya",
+        "Downtown Izakaya",
+        35.0105,
+        135.7705,
+        types=["restaurant", "bar", "food"],
+    )
+
+    riverside_cafe = _place(
+        "riverside-cafe",
+        "Riverside Breakfast",
+        35.0090,
+        135.7700,
+        types=["restaurant", "cafe", "food"],
+    )
+    art_museum = _place(
+        "art-museum",
+        "Kyoto Art Museum",
+        35.0140,
+        135.7800,
+        types=["museum", "point_of_interest"],
+    )
+    zen_garden = _place(
+        "zen-garden",
+        "Zen Garden",
+        35.0180,
+        135.7760,
+        types=["park", "tourist_attraction"],
+    )
+    kaiseki_dinner = _place(
+        "kaiseki",
+        "Kaiseki Dinner",
+        35.0115,
+        135.7690,
+        types=["restaurant", "food"],
+    )
+
+    return Itinerary(
+        destination="Kyoto",
+        start_date=date(2024, 6, 1),
+        end_date=date(2024, 6, 3),
+        days=[
+            DayPlan(
+                label="Day 1",
+                events=[
+                    ItineraryEvent(
+                        title="Breakfast at Morning Cafe",
+                        start_time=time(8, 0),
+                        end_time=time(9, 0),
+                        place=morning_cafe,
+                        tags=["meal", "breakfast"],
+                    ),
+                    ItineraryEvent(
+                        title="Walk through the Bamboo Grove",
+                        start_time=time(9, 30),
+                        end_time=time(11, 0),
+                        place=bamboo_grove,
+                        tags=["nature"],
+                    ),
+                    ItineraryEvent(
+                        title="Traditional Tea Ceremony",
+                        start_time=time(13, 0),
+                        end_time=time(15, 0),
+                        place=tea_house,
+                        tags=["culture"],
+                    ),
+                    ItineraryEvent(
+                        title="Dinner at local izakaya",
+                        start_time=time(18, 30),
+                        end_time=time(20, 0),
+                        place=downtown_izakaya,
+                        tags=["meal", "dinner"],
+                    ),
+                ],
+            ),
+            DayPlan(
+                label="Day 2",
+                events=[
+                    ItineraryEvent(
+                        title="Riverside breakfast",
+                        start_time=time(8, 30),
+                        end_time=time(9, 30),
+                        place=riverside_cafe,
+                        tags=["meal", "breakfast"],
+                    ),
+                    ItineraryEvent(
+                        title="Explore Kyoto Art Museum",
+                        start_time=time(10, 0),
+                        end_time=time(12, 30),
+                        place=art_museum,
+                        tags=["art"],
+                    ),
+                    ItineraryEvent(
+                        title="Stroll the Zen Garden",
+                        start_time=time(14, 0),
+                        end_time=time(16, 0),
+                        place=zen_garden,
+                        tags=["relaxation"],
+                    ),
+                    ItineraryEvent(
+                        title="Evening kaiseki dinner",
+                        start_time=time(18, 0),
+                        end_time=time(20, 0),
+                        place=kaiseki_dinner,
+                        tags=["meal", "dinner"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def test_daily_distance_sanity() -> None:
+    itinerary = _build_sample_itinerary()
+    distances = daily_transfer_distance_km(itinerary)
+
+    assert distances, "Expected daily distance data to be calculated"
+    assert all(total < 15 for total in distances.values())
+
+
+def test_opening_hours_conflicts_zero() -> None:
+    itinerary = _build_sample_itinerary()
+    assert opening_hours_conflicts(itinerary) == 0
+
+
+def test_category_diversity_threshold() -> None:
+    itinerary = _build_sample_itinerary()
+    assert category_diversity_score(itinerary) >= 4
+
+
+def test_meal_coverage_present_each_day() -> None:
+    itinerary = _build_sample_itinerary()
+    assert has_meal_coverage(itinerary)


### PR DESCRIPTION
## Summary
- add core evaluation helpers for itineraries to measure travel distance, schedule conflicts, diversity, and meal coverage
- add regression tests covering itinerary evaluation heuristics
- configure a GitHub Actions workflow to run pytest and comment results on pull requests

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cdc13e4c988328bc2b0165b463f4a8