### PR TITLE
Ensure Poetry CLI is installed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,14 @@ jobs:
           python-version: "3.11"
           cache: "poetry"
 
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --user poetry
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
-          pip install poetry
           poetry install
 
       - name: Run tests


### PR DESCRIPTION
## Summary
- add a dedicated CI step that installs Poetry with pip and exposes the user's local bin directory
- keep the existing Poetry-powered install and test steps so they run after the CLI is available

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cdc69524cc8328b69b17fda86a0a45