### PR TITLE
Add Azure Pipelines definition with Poetry bootstrap

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,0 +1,22 @@
+trigger:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - checkout: self
+
+  - script: |
+      python -m pip install --upgrade pip
+      python -m pip install --user poetry
+      echo "##vso[task.prependpath]$(python -m site --user-base)/bin"
+    displayName: 'Install Poetry via pip'
+
+  - script: poetry install
+    displayName: 'Install dependencies'
+
+  - script: poetry run pytest
+    displayName: 'Run tests'


### PR DESCRIPTION
## Summary
- add an Azure Pipelines definition that runs on ubuntu-latest
- ensure the pipeline installs Poetry via pip before invoking existing Poetry commands

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdca7b688c8328a9a2a25b105d1844