### PR TITLE
Handle nested itinerary responses from planner agent

### DIFF
--- a/tests/test_profile_and_exports.py
+++ b/tests/test_profile_and_exports.py
@@ -33,6 +33,33 @@ def _sample_trip() -> tuple[TripIntent, Itinerary]:
     return intent, itinerary
 
 
+def test_itinerary_accepts_wrapped_payloads():
+    itinerary = Itinerary.model_validate(
+        {
+            "itinerary": {
+                "trip": {
+                    "destination": "Tokyo",
+                    "days": [
+                        {
+                            "label": "Day 1",
+                            "events": [
+                                {
+                                    "title": "Tsukiji Outer Market breakfast",
+                                    "start_time": "08:30",
+                                    "end_time": "10:00",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            }
+        }
+    )
+
+    assert itinerary.destination == "Tokyo"
+    assert itinerary.days[0].events[0].title.startswith("Tsukiji")
+
+
 def test_itinerary_to_ics_contains_events():
     _, itinerary = _sample_trip()
     ics_data = itinerary_to_ics(itinerary, calendar_name="Kyoto Adventure")


### PR DESCRIPTION
## Summary
- allow the Itinerary schema to unwrap common nested keys returned by the planner LLM
- add a regression test covering validation of a wrapped payload

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d46a228e4c83288a9c35179cdf96a6