### PR TITLE
Fix planner schema wrapper unwrapping

### DIFF
--- a/meguru/schemas.py
+++ b/meguru/schemas.py
@@ -279,8 +279,10 @@ class Itinerary(BaseModel):
 
         candidate = data
         for key in ("itinerary", "trip"):
-            nested = candidate.get(key)
-            if isinstance(nested, dict):
+            while isinstance(candidate, dict):
+                nested = candidate.get(key)
+                if not isinstance(nested, dict):
+                    break
                 candidate = nested
 
         return candidate


### PR DESCRIPTION
## Summary
- update the itinerary schema wrapper handling to repeatedly unwrap nested `itinerary` and `trip` keys so deeply nested payloads validate correctly

## Testing
- pytest meguru/tests/test_trip_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d47d18472c832891154a45c953ec3d