### PR TITLE
Ensure ResearchItem propagates place ids

### DIFF
--- a/meguru/schemas.py
+++ b/meguru/schemas.py
@@ -132,14 +132,16 @@ class ResearchItem(BaseModel):
                 place_data["formatted_address"] = place_data.pop("address")
             payload["place"] = place_data
 
+        place_payload = payload.get("place") if isinstance(payload.get("place"), dict) else None
+
         if not payload.get("place_id"):
             candidate_id = None
-            if isinstance(payload.get("place"), dict):
-                candidate_id = payload["place"].get("place_id")
+            if isinstance(place_payload, dict):
+                candidate_id = place_payload.get("place_id")
 
             if not candidate_id:
                 slug_parts: List[str] = []
-                place = payload.get("place") or {}
+                place = place_payload or {}
                 if isinstance(place, dict):
                     if place.get("name"):
                         slug_parts.append(str(place["name"]))
@@ -162,8 +164,11 @@ class ResearchItem(BaseModel):
 
             if candidate_id:
                 payload["place_id"] = candidate_id
-                if isinstance(payload.get("place"), dict) and not payload["place"].get("place_id"):
-                    payload["place"]["place_id"] = candidate_id
+                place_payload = payload.get("place") if isinstance(payload.get("place"), dict) else None
+                if isinstance(place_payload, dict) and not place_payload.get("place_id"):
+                    place_payload["place_id"] = candidate_id
+        elif isinstance(place_payload, dict) and not place_payload.get("place_id"):
+            place_payload["place_id"] = payload["place_id"]
 
         return payload
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,20 @@
+"""Unit tests for schema helpers and validators."""
+
+from meguru.schemas import ResearchItem
+
+
+def test_research_item_copies_place_id_into_nested_place() -> None:
+    """LLM responses may omit the place id from the nested place structure."""
+
+    item = ResearchItem.model_validate(
+        {
+            "place_id": "places/123",
+            "place": {
+                "name": "Freehand Los Angeles",
+                "formatted_address": "416 W 8th St, Los Angeles, CA 90014, USA",
+            },
+        }
+    )
+
+    assert item.place is not None
+    assert item.place.place_id == "places/123"


### PR DESCRIPTION
## Summary
- ensure ResearchItem pre-validation always mirrors the place_id into any nested place payload
- add a regression test that covers ResearchItem validation of nested place data

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d48597c9e88328bdcac82ec5c23fd8