### PR TITLE
Enhance itinerary planner with detailed daily schedules

### DIFF
--- a/meguru/agents/planner.py
+++ b/meguru/agents/planner.py
@@ -20,7 +20,11 @@ class PlannerAgent:
 
     system_prompt = (
         "You are a meticulous travel planner. Create a paced itinerary that respects "
-        "opening hours and reasonable travel distances. Respond with JSON conforming to the "
+        "opening hours and reasonable travel distances. Provide chronologically ordered "
+        "events that include start_time, end_time when possible, duration_minutes, location, "
+        "and a brief justification. Use the event category field to denote the slot "
+        "(wake_up, breakfast, morning_activity, snack_morning, lunch, afternoon_activity, "
+        "snack_afternoon, dinner, evening_activity). Respond with JSON conforming to the "
         "Itinerary schema."
     )
     prompt_version = "planner.v1"
@@ -63,8 +67,16 @@ class PlannerAgent:
         prompt = (
             "Design a day-by-day itinerary that balances activity pace, observes opening hours, "
             "and minimises unnecessary backtracking.\n"
-            "Include descriptive summaries for each day and ensure activities map back to the "
-            "ranked places when relevant.\n"
+            "For each day, produce a cohesive theme (store this in the day summary) and a full "
+            "schedule covering wake-up, breakfast, morning activity, optional morning snack, "
+            "lunch, afternoon activity, optional afternoon snack, dinner, and optional evening "
+            "activity.\n"
+            "Populate each itinerary event with: category (one of the slots listed above), "
+            "start_time in 24-hour HH:MM format, duration_minutes, end_time when known, a "
+            "clear title, the location or place_id, and a short justification explaining why "
+            "it suits the traveller preferences.\n"
+            "If a researched place aligns, reference it by place_id; otherwise include a free-"
+            "text location. Keep meal stops distinctive from activities.\n"
             "\n"
             "# Planning Context\n"
             f"{format_prompt_data(prompt_payload)}\n"

--- a/meguru/schemas.py
+++ b/meguru/schemas.py
@@ -310,8 +310,47 @@ class ItineraryEvent(BaseModel):
     place_id: Optional[str] = None
     start_time: Optional[time] = None
     end_time: Optional[time] = None
+    duration_minutes: Optional[int] = Field(
+        default=None,
+        ge=0,
+        validation_alias=AliasChoices(
+            "duration_minutes",
+            "duration",
+            "estimated_duration_minutes",
+            "estimated_duration",
+        ),
+    )
+    category: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("category", "type", "slot", "kind"),
+    )
+    location: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "location",
+            "venue",
+            "where",
+            "meeting_point",
+        ),
+    )
+    justification: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("justification", "why", "reason", "rationale"),
+    )
     tags: List[str] = Field(default_factory=list)
     place: Optional[Place] = None
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def _normalise_category(cls, value: object) -> Optional[str]:
+        if not isinstance(value, str):
+            return value  # type: ignore[return-value]
+        candidate = value.strip()
+        if not candidate:
+            return None
+        normalised = candidate.lower().replace("-", "_")
+        normalised = re.sub(r"\s+", "_", normalised)
+        return normalised
 
 
 class DayPlan(BaseModel):

--- a/meguru/tests/test_trip_pipeline.py
+++ b/meguru/tests/test_trip_pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import date
+from datetime import date, time
 from typing import Dict, Optional
 
 import pytest
@@ -53,15 +53,85 @@ def _build_itinerary(destination: str) -> Itinerary:
         days=[
             DayPlan(
                 label="Day 1",
+                summary="Cultural immersion and flavours",
                 events=[
-                    ItineraryEvent(title="Breakfast at cafe", place_id="dine-1"),
-                    ItineraryEvent(title="Morning walk", place_id="exp-1"),
-                    ItineraryEvent(title="Afternoon temple", place_id="exp-2"),
+                    ItineraryEvent(
+                        title="Wake up refreshed",
+                        category="wake_up",
+                        start_time=time(7, 0),
+                        duration_minutes=30,
+                        description="Light stretching and hydration at your hotel.",
+                        justification="Gives you time to acclimate before breakfast.",
+                    ),
+                    ItineraryEvent(
+                        title="Breakfast at cafe",
+                        category="breakfast",
+                        start_time=time(7, 30),
+                        duration_minutes=60,
+                        place_id="dine-1",
+                        description="Savour seasonal pastries and coffee.",
+                        justification="Highly rated spot that aligns with your love of food adventures.",
+                    ),
+                    ItineraryEvent(
+                        title="Morning walk",
+                        category="morning_activity",
+                        start_time=time(9, 0),
+                        duration_minutes=90,
+                        place_id="exp-1",
+                        description="Stroll the historic streets and capture photos.",
+                        justification="Showcases Kyoto's culture at a relaxed pace.",
+                    ),
+                    ItineraryEvent(
+                        title="Lunch at Nishiki Market",
+                        category="lunch",
+                        start_time=time(12, 30),
+                        duration_minutes=75,
+                        location="Nishiki Market Food Stalls",
+                        description="Sample local bites and sweets.",
+                        justification="An ideal way to graze through Kyoto specialities.",
+                    ),
+                    ItineraryEvent(
+                        title="Afternoon temple",
+                        category="afternoon_activity",
+                        start_time=time(14, 30),
+                        duration_minutes=120,
+                        place_id="exp-2",
+                        description="Explore Kiyomizu-dera's wooden terrace.",
+                        justification="Iconic landmark that fits your cultural interests.",
+                    ),
+                    ItineraryEvent(
+                        title="Dinner tasting menu",
+                        category="dinner",
+                        start_time=time(19, 0),
+                        duration_minutes=90,
+                        place_id="dine-1",
+                        description="Multi-course kaiseki-inspired meal.",
+                        justification="Celebrates Kyoto flavours in an intimate setting.",
+                    ),
                 ],
             ),
             DayPlan(
                 label="Day 2",
-                events=[ItineraryEvent(title="Museum visit", place_id="exp-3")],
+                summary="Art and design inspirations",
+                events=[
+                    ItineraryEvent(
+                        title="Wake slowly",
+                        category="wake_up",
+                        start_time=time(8, 0),
+                        duration_minutes=30,
+                        description="Gentle start with tea in your room.",
+                        justification="Keeps the day relaxed after a big first day.",
+                    ),
+                    ItineraryEvent(
+                        title="Museum visit",
+                        category="morning_activity",
+                        start_time=time(10, 0),
+                        duration_minutes=120,
+                        place_id="exp-3",
+                        description="Discover modern art installations.",
+                        justification="Matches your interest in design and creativity.",
+                    ),
+                ],
             ),
         ],
     )


### PR DESCRIPTION
## Summary
- expand the planner agent instructions so each day includes a full schedule with timing, location, and justification metadata
- extend itinerary events with category, duration, location, and reasoning fields while updating UI and exports to surface the richer data
- refresh pipeline tests with representative detailed sample data to guard the new structure

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d48e154748832895d37e3c4da286d2