### PR TITLE
Handle OpenAI rate limit errors

### DIFF
--- a/meguru/ui/plan.py
+++ b/meguru/ui/plan.py
@@ -571,6 +571,10 @@ def _format_pipeline_error(exc: Exception) -> str:
                 f"{base_message} Provide an OpenAI API key via the "
                 "OPENAI_API_KEY environment variable."
             )
+        if "429" in lowered or "too many requests" in lowered:
+            return (
+                f"{base_message} The OpenAI API rate limit was hit. Wait a moment and try again."
+            )
         return f"{base_message} {details}"
     return f"{base_message} Check your configuration and try again."
 

--- a/tests/ui/test_plan_errors.py
+++ b/tests/ui/test_plan_errors.py
@@ -21,6 +21,12 @@ from meguru.ui import plan
             "Unable to generate the itinerary. Provide an OpenAI API key via the OPENAI_API_KEY environment variable.",
         ),
         (
+            RuntimeError(
+                "Client error '429 Too Many Requests' for url 'https://api.openai.com/v1/chat/completions'"
+            ),
+            "Unable to generate the itinerary. The OpenAI API rate limit was hit. Wait a moment and try again.",
+        ),
+        (
             ValueError("LLM quota exceeded"),
             "Unable to generate the itinerary. LLM quota exceeded",
         ),


### PR DESCRIPTION
## Summary
- provide a dedicated user-facing message when the OpenAI chat completions API returns a 429 rate limit error
- extend the planner error handling tests to cover the rate limit scenario

## Testing
- PYTHONPATH=. poetry run pytest tests/ui/test_plan_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68db220cd380832887794bcd07218acb