### PR TITLE
Ensure interest gallery images use container width

### DIFF
--- a/meguru/ui/plan.py
+++ b/meguru/ui/plan.py
@@ -368,7 +368,7 @@ def _render_interest_gallery(container, state: Dict[str, object]) -> None:
     for idx, card in enumerate(_EXPERIENCE_CARDS):
         target = columns[idx % len(columns)]
         with target:
-            st.image(card["image_url"], use_column_width=True)
+            st.image(card["image_url"], use_container_width=True)
             st.markdown(f"**{card['title']}**")
             st.caption(card["description"])
             st.caption(f"_{card['location_hint']}_")


### PR DESCRIPTION
## Summary
- switch the experience card images in the interest gallery to Streamlit's `use_container_width` parameter to keep them full width within their columns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ded351426c8328b913620f68ece40e