### PR TITLE
Persist curated inspirations throughout planning

### DIFF
--- a/meguru/schemas.py
+++ b/meguru/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time
 import re
-from typing import Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from pydantic import (
     AliasChoices,
@@ -65,6 +65,8 @@ class TripIntent(BaseModel):
     dining_preferences: List[str] = Field(default_factory=list)
     lodging_preferences: List[str] = Field(default_factory=list)
     notes: Optional[str] = None
+    liked_inspirations: List[Dict[str, Any]] = Field(default_factory=list)
+    saved_inspirations: List[Dict[str, Any]] = Field(default_factory=list)
 
     model_config = ConfigDict(populate_by_name=True)
 


### PR DESCRIPTION
## Summary
- preserve the full payload of liked and saved inspiration cards in the planner state and trip intent
- ensure the planning workflow and planner agent prioritise traveller-selected activities when generating itineraries
- surface saved and liked inspirations in the itinerary tab so travellers can see their curated picks reflected

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dee3146d6c8328afa478117b12e12d