### PR TITLE
Replace deprecated Streamlit rerun helper

### DIFF
--- a/meguru/ui/itinerary.py
+++ b/meguru/ui/itinerary.py
@@ -454,7 +454,7 @@ def _handle_swap_request(
     )
     st.session_state[_SWAP_SUCCESS_KEY] = success_message
     _close_swap()
-    st.experimental_rerun()
+    st.rerun()
 
 
 def _render_swap_modal(itinerary: Itinerary) -> None:
@@ -506,7 +506,7 @@ def _render_swap_modal(itinerary: Itinerary) -> None:
         actions = st.columns(2)
         if actions[0].button("Cancel", key="swap_cancel"):
             _close_swap()
-            st.experimental_rerun()
+            st.rerun()
             return
 
         if actions[1].button("Request swap", type="primary", key="swap_submit"):

--- a/meguru/ui/plan.py
+++ b/meguru/ui/plan.py
@@ -481,7 +481,7 @@ def _render_conversation(container, state: Dict[str, object]) -> None:
                     state["notes"] = ""
                     state.pop("timing_note", None)
                     _ensure_conversation_intro(state)
-                    st.experimental_rerun()
+                    st.rerun()
 
     user_text = st.chat_input("Tell me what's essential for this trip…")
     if user_text:
@@ -612,7 +612,7 @@ def _render_cinematic_intro(container, state: Dict[str, object]) -> None:
                 state,
                 {"type": "message", "text": cleaned_destination},
             )
-            st.experimental_rerun()
+            st.rerun()
 
     container.caption("You can always come back to change the destination later.")
 

--- a/meguru/ui/profile.py
+++ b/meguru/ui/profile.py
@@ -113,7 +113,7 @@ def _render_auth_controls(client: SupabaseClient) -> None:
                         "expires_at": session.expires_at,
                     }
                     st.session_state[PROFILE_STATUS_KEY] = "Signed in successfully."
-                    st.experimental_rerun()
+                    st.rerun()
 
 
 def _render_user_summary(session: SupabaseSession) -> None:
@@ -126,7 +126,7 @@ def _render_user_summary(session: SupabaseSession) -> None:
         st.session_state.pop(SUPABASE_SESSION_KEY, None)
         st.session_state.pop(SUPABASE_TOKENS_KEY, None)
         st.session_state[PROFILE_STATUS_KEY] = "Signed out."
-        st.experimental_rerun()
+        st.rerun()
 
 
 def _load_trips(store: InMemoryProfileStore | SupabaseProfileStore) -> List[StoredTrip]:
@@ -181,7 +181,7 @@ def _render_trip_summary(trip: StoredTrip, store: InMemoryProfileStore | Supabas
             else:
                 if duplicate:
                     st.session_state[PROFILE_STATUS_KEY] = f"Duplicated {trip.name}."
-                    st.experimental_rerun()
+                    st.rerun()
 
         st.markdown("### Day by day")
         for day in trip.itinerary.days:

--- a/tests/ui/test_itinerary_profile_fallback.py
+++ b/tests/ui/test_itinerary_profile_fallback.py
@@ -115,7 +115,7 @@ class _FakeStreamlit:
     def spinner(self, *args: Any, **kwargs: Any):  # noqa: ARG002
         return nullcontext()
 
-    def experimental_rerun(self) -> None:
+    def rerun(self) -> None:
         return None
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun()` calls with `st.rerun()` in plan, itinerary, and profile flows
- update the test double used in itinerary/profile UI tests to expose the new `st.rerun()` helper

## Testing
- `poetry run pytest tests/ui/test_itinerary_profile_fallback.py` *(fails: ModuleNotFoundError: No module named 'meguru')*

------
https://chatgpt.com/codex/tasks/task_e_68dee66768188328921e2185e931712c