### PR TITLE
Remove transcript recap from plan flow

### DIFF
--- a/meguru/ui/plan.py
+++ b/meguru/ui/plan.py
@@ -595,24 +595,6 @@ def _render_cinematic_intro(container, state: Dict[str, object]) -> None:
     container.caption("Start the conversation below—destination, crew, vibes, I'm listening.")
 
 
-def _render_conversation_transcript(container, state: Dict[str, object]) -> None:
-    try:
-        messages = list(_conversation_log(state))
-    except Exception:  # pragma: no cover - defensive fallback
-        conversation = state.get("conversation") if isinstance(state.get("conversation"), dict) else {}
-        messages = list(conversation.get("messages", []))
-    if not messages:
-        return
-
-    container.subheader("Trip setup recap")
-    transcript_area = container.container()
-    for message in messages:
-        role = message.get("role", "assistant")
-        content = message.get("content", "")
-        with transcript_area.chat_message(role):
-            st.markdown(content)
-
-
 def _render_interest_gallery(container, state: Dict[str, object]) -> None:
     destination = state.get("destination") or "your trip"
     container.markdown(
@@ -988,7 +970,6 @@ def render_plan_tab(container) -> None:
     state = _wizard_state()
 
     with container:
-        transcript_area = st.container()
         body_area = st.container()
 
         scene = str(state.get("scene") or "conversation")
@@ -996,9 +977,6 @@ def render_plan_tab(container) -> None:
         if scene not in {"conversation", "interests", "review", "welcome"}:
             scene = "conversation"
             state["scene"] = scene
-
-        if scene in {"interests", "review"}:
-            _render_conversation_transcript(transcript_area, state)
 
         if scene == "welcome":
             _render_cinematic_intro(body_area, state)


### PR DESCRIPTION
## Summary
- remove the conversation transcript renderer so messages only appear in the live chat flow
- simplify the plan tab layout to use a single container when switching scenes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68def84affe883289bfddc84f0f521ca