### PR TITLE
Implement trip brief memory and refine gallery flow

### DIFF
--- a/meguru/agents/__init__.py
+++ b/meguru/agents/__init__.py
@@ -68,6 +68,7 @@ from .curator import Curator, CuratorDraft
 from .editor import Editor, EditorRevision
 from .intake import IntakeAgent
 from .listener import Listener, ListenerResult
+from .memory import TripBrief, TripBriefMemory
 from .planner import PlannerAgent
 from .planning import Planner, PlannerBrief
 from .refiner import RefinerAgent
@@ -88,6 +89,8 @@ __all__ = [
     "IntakeAgent",
     "Listener",
     "ListenerResult",
+    "TripBrief",
+    "TripBriefMemory",
     "Planner",
     "PlannerAgent",
     "PlannerBrief",

--- a/meguru/agents/listener.py
+++ b/meguru/agents/listener.py
@@ -205,7 +205,10 @@ def _extract_mood(text: str) -> Optional[str]:
 
 def _infer_travel_pace(text: str) -> Optional[str]:
     lowered = _normalise(text)
-    if any(token in lowered for token in ("relax", "slow", "chill", "easy", "unhurried")):
+    laid_back_markers = ("laid back", "laid-back", "laidback")
+    if any(token in lowered for token in laid_back_markers) or any(
+        token in lowered for token in ("relax", "slow", "chill", "easy", "unhurried")
+    ):
         return "Laid back"
     if any(token in lowered for token in ("balanced", "mix", "medium", "moderate")):
         return "Balanced"

--- a/meguru/agents/memory.py
+++ b/meguru/agents/memory.py
@@ -1,0 +1,172 @@
+"""Trip brief memory agent that persists traveller intent across turns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+
+def _clean_text(value: object) -> str | None:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or None
+    if value is None:
+        return None
+    return str(value).strip() or None
+
+
+def _coerce_positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float) and value.is_integer():
+        numeric = int(value)
+        return numeric if numeric > 0 else None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        try:
+            numeric = int(cleaned)
+        except ValueError:
+            return None
+        return numeric if numeric > 0 else None
+    try:
+        numeric = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return numeric if numeric > 0 else None
+
+
+_OCCASION_KEYWORDS = {
+    "anniversary": "anniversary",
+    "honeymoon": "honeymoon",
+    "birthday": "birthday",
+    "proposal": "proposal",
+    "babymoon": "babymoon",
+}
+
+_MOOD_TONES = {
+    "burned_out": "soothing",
+    "celebration": "celebratory",
+    "peaceful": "calm",
+}
+
+
+@dataclass
+class TripBrief:
+    """Canonical snapshot of the traveller's intent."""
+
+    destination: Optional[str] = None
+    group_type: Optional[str] = None
+    group_size: Optional[int] = None
+    travel_pace: Optional[str] = None
+    budget: Optional[str] = None
+    vibes: List[str] = field(default_factory=list)
+    mood: Optional[str] = None
+    tone: Optional[str] = None
+    occasion: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "destination": self.destination,
+            "group_type": self.group_type,
+            "group_size": self.group_size,
+            "travel_pace": self.travel_pace,
+            "budget": self.budget,
+            "vibes": list(self.vibes),
+            "mood": self.mood,
+            "tone": self.tone,
+            "occasion": self.occasion,
+        }
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TripBrief":
+        vibes = []
+        raw_vibes = data.get("vibes")
+        if isinstance(raw_vibes, Iterable) and not isinstance(raw_vibes, (str, bytes)):
+            vibes = [
+                str(item).strip()
+                for item in raw_vibes
+                if isinstance(item, str) and item.strip()
+            ]
+
+        return cls(
+            destination=_clean_text(data.get("destination")),
+            group_type=_clean_text(data.get("group_type")),
+            group_size=_coerce_positive_int(data.get("group_size")),
+            travel_pace=_clean_text(data.get("travel_pace")),
+            budget=_clean_text(data.get("budget")),
+            vibes=vibes,
+            mood=_clean_text(data.get("mood")),
+            tone=_clean_text(data.get("tone")),
+            occasion=_clean_text(data.get("occasion")),
+        )
+
+
+class TripBriefMemory:
+    """Maintains a persistent trip brief based on listener updates."""
+
+    def __init__(self) -> None:
+        self._brief = TripBrief()
+
+    def update(self, state: Mapping[str, Any]) -> TripBrief:
+        """Synchronise the memory with the latest planner state."""
+
+        destination = _clean_text(state.get("destination"))
+        group_type = _clean_text(state.get("group_type"))
+        group_size = _coerce_positive_int(state.get("group_size"))
+        travel_pace = _clean_text(state.get("travel_pace"))
+        budget = _clean_text(state.get("budget"))
+        mood = _clean_text(state.get("mood"))
+        tone = _clean_text(state.get("tone"))
+
+        vibes: List[str] = []
+        raw_vibes = state.get("vibe")
+        if isinstance(raw_vibes, Iterable) and not isinstance(raw_vibes, (str, bytes)):
+            seen: Dict[str, None] = {}
+            for item in raw_vibes:
+                cleaned = _clean_text(item)
+                if cleaned and cleaned.lower() not in seen:
+                    seen[cleaned.lower()] = None
+                    vibes.append(cleaned)
+
+        occasion = _clean_text(state.get("occasion"))
+        if not occasion:
+            note_text = " ".join(
+                str(state.get(key, "")) for key in ("notes", "timing_note") if state.get(key)
+            ).lower()
+            for keyword, label in _OCCASION_KEYWORDS.items():
+                if keyword in note_text:
+                    occasion = label
+                    break
+
+        if not tone and mood:
+            tone = _MOOD_TONES.get(mood.lower())
+
+        brief = TripBrief(
+            destination=destination or self._brief.destination,
+            group_type=group_type or self._brief.group_type,
+            group_size=group_size or self._brief.group_size,
+            travel_pace=travel_pace or self._brief.travel_pace,
+            budget=budget or self._brief.budget,
+            vibes=vibes or list(self._brief.vibes),
+            mood=mood or self._brief.mood,
+            tone=tone or self._brief.tone,
+            occasion=occasion or self._brief.occasion,
+        )
+
+        self._brief = brief
+        return brief
+
+    @property
+    def brief(self) -> TripBrief:
+        return self._brief
+
+    def serialise(self) -> Dict[str, Any]:
+        return self._brief.to_dict()
+
+
+__all__ = ["TripBrief", "TripBriefMemory"]
+

--- a/meguru/tests/test_listener.py
+++ b/meguru/tests/test_listener.py
@@ -1,0 +1,6 @@
+from meguru.agents.listener import _infer_travel_pace
+
+
+def test_infer_travel_pace_recognises_laid_back_phrases() -> None:
+    assert _infer_travel_pace("Let's keep it laid back and easy") == "Laid back"
+    assert _infer_travel_pace("We're thinking a laid-back escape") == "Laid back"

--- a/meguru/tests/test_plan_gallery.py
+++ b/meguru/tests/test_plan_gallery.py
@@ -1,0 +1,49 @@
+from meguru.ui.plan import _prepare_activity_cards
+
+
+def _base_state() -> dict:
+    return {
+        "destination": "Kyoto",
+        "vibe": ["Outdoors & nature"],
+        "travel_pace": "Laid back",
+        "budget": "Shoestring",
+        "group_type": "Partner getaway",
+        "mood": "peaceful",
+        "trip_brief": {
+            "destination": "Kyoto",
+            "vibes": ["Outdoors & nature"],
+            "travel_pace": "Laid back",
+            "budget": "Shoestring",
+            "group_type": "Partner getaway",
+            "mood": "peaceful",
+            "tone": "calm",
+        },
+        "custom_interests": [],
+        "liked_cards": [],
+        "saved_cards": [],
+        "liked_inspirations": [],
+        "saved_inspirations": [],
+        "_activity_catalog": {},
+    }
+
+
+def test_prepare_activity_cards_prioritises_brief_matches() -> None:
+    state = _base_state()
+    cards, _, _ = _prepare_activity_cards(state)
+    assert cards
+    # Gallery is capped to top matches
+    assert len(cards) <= 4
+    assert cards[0]["id"] == "forest_baths"
+
+
+def test_prepare_activity_cards_retains_liked_cards() -> None:
+    state = _base_state()
+    state["liked_cards"] = ["neon_bazaar"]
+    state["trip_brief"]["vibes"].append("Nightlife")
+
+    cards, likes, _ = _prepare_activity_cards(state)
+    ids = [card["id"] for card in cards]
+
+    assert "neon_bazaar" in ids
+    # Forced cards still count toward the target length
+    assert len(cards) >= len(likes)

--- a/meguru/tests/test_plan_workflow.py
+++ b/meguru/tests/test_plan_workflow.py
@@ -1,0 +1,30 @@
+from meguru.workflows.plan_chat import PlanConversationWorkflow
+
+
+def test_selected_card_ids_collects_unique_cards() -> None:
+    state = {
+        "liked_cards": ["alpha", "beta"],
+        "saved_cards": ["beta", "gamma"],
+        "liked_inspirations": [{"id": "delta"}],
+        "saved_inspirations": [{"id": "gamma"}],
+    }
+
+    ids = PlanConversationWorkflow._selected_card_ids(state)
+    assert ids == {"alpha", "beta", "gamma", "delta"}
+
+
+def test_has_prioritised_activity_requires_three_picks() -> None:
+    state = {
+        "liked_cards": ["one"],
+        "saved_cards": [],
+        "liked_inspirations": [],
+        "saved_inspirations": [],
+    }
+
+    assert not PlanConversationWorkflow._has_prioritised_activity(state)
+
+    state["saved_cards"].append("two")
+    assert not PlanConversationWorkflow._has_prioritised_activity(state)
+
+    state["liked_inspirations"].append({"id": "three"})
+    assert PlanConversationWorkflow._has_prioritised_activity(state)

--- a/meguru/tests/test_trip_brief_memory.py
+++ b/meguru/tests/test_trip_brief_memory.py
@@ -1,0 +1,56 @@
+from meguru.agents.curator import Curator
+from meguru.agents.listener import ListenerResult
+from meguru.agents.memory import TripBriefMemory
+
+
+def test_trip_brief_memory_persists_core_fields() -> None:
+    memory = TripBriefMemory()
+    state = {
+        "destination": "Kyoto",
+        "group_type": "Partner getaway",
+        "group_size": 2,
+        "travel_pace": "Laid back",
+        "budget": "Moderate",
+        "notes": "We're celebrating our anniversary with slow mornings.",
+        "vibe": ["Foodie adventures"],
+    }
+
+    brief = memory.update(state)
+    assert brief.destination == "Kyoto"
+    assert brief.group_type == "Partner getaway"
+    assert brief.occasion == "anniversary"
+
+    state["mood"] = "celebration"
+    state["vibe"].append("Nightlife")
+
+    updated = memory.update(state)
+    assert updated.destination == "Kyoto"
+    assert updated.tone == "celebratory"
+    assert set(updated.vibes) == {"Foodie adventures", "Nightlife"}
+
+
+def test_curator_references_trip_brief_summary() -> None:
+    curator = Curator()
+    listener_result = ListenerResult(
+        action_type="message",
+        user_message="",
+        context_updates={},
+        missing_context=[],
+        resolved_fields=[],
+        trigger_planning=False,
+    )
+    context = {
+        "destination": "Kyoto",
+        "trip_brief": {
+            "destination": "Kyoto",
+            "vibes": ["Foodie adventures"],
+            "travel_pace": "Laid back",
+            "budget": "Moderate",
+            "group_type": "Partner getaway",
+        },
+    }
+
+    draft = curator.run(listener_result, context)
+    combined = " ".join(draft.lines).lower()
+    assert "kyoto" in combined
+    assert "laid back" in combined or "budget" in combined


### PR DESCRIPTION
## Summary
- add a TripBriefMemory agent that persists key trip intent and feeds the curator, stylist, and workflow state
- weight gallery scoring by group type, tone, and mood while capping the gallery to top matches and narrating the transition from the stored brief
- gate itinerary generation on three curated picks, refresh the curator narrative, and extend coverage with new listener, gallery, memory, and workflow tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6b49a030083288fa2a140e921d4cd